### PR TITLE
Move secrets mount path to /var/openfaas/secrets

### DIFF
--- a/pkg/controller/secrets.go
+++ b/pkg/controller/secrets.go
@@ -8,6 +8,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	secretsMountPath = "/var/openfaas/secrets"
+)
+
 // UpdateSecrets will update the Deployment spec to include secrets that have been deployed
 // in the kubernetes cluster.  For each requested secret, we inspect the type and add it to the
 // deployment spec as appropriate: secrets with type `SecretTypeDockercfg` are added as ImagePullSecrets
@@ -78,7 +82,7 @@ func UpdateSecrets(function *faasv1alpha1.Function, deployment *appsv1beta2.Depl
 		mount := corev1.VolumeMount{
 			Name:      volumeName,
 			ReadOnly:  true,
-			MountPath: "/run/secrets",
+			MountPath: secretsMountPath,
 		}
 		// remove the existing secrets volume mount, if we can find it. We update it later.
 		container.VolumeMounts = removeVolumeMount(volumeName, container.VolumeMounts)

--- a/pkg/controller/secrets_test.go
+++ b/pkg/controller/secrets_test.go
@@ -283,4 +283,8 @@ func validateNewSecretVolumesAndMounts(t *testing.T, deployment *appsv1beta2.Dep
 	if mount.Name != "testfunc-projected-secrets" {
 		t.Errorf("Incorrect volume mounts: expected \"testfunc-projected-secrets\", got \"%s\"", mount.Name)
 	}
+
+	if mount.MountPath != secretsMountPath {
+		t.Errorf("Incorrect volume mount path: expected \"%s\", got \"%s\"", secretsMountPath, mount.MountPath)
+	}
 }


### PR DESCRIPTION
**What**
- create `secretsMountPath` constant
- update the volume mount to set the mount path to the `secretsMountPath`

**Why**
- this will ensure that the secrets required for the function business
logic do not interfer with standard locations that other systems may
want to modify.

**Notes**
Implement openfaas/faas#692

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>