### PR TITLE
 Fix ClusterIP creation race condition and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ Test that secrets are available inside the `gofast` pod:
 ```bash
 kubectl -n openfaas-fn exec -it gofast-84fd464784-sd5ml -- sh
 
-~ $ cat /run/secrets/faas-key 
+~ $ cat /var/openfaas/faas-key 
 key
 
-~ $ cat /run/secrets/faas-token 
+~ $ cat /var/openfaas/faas-token 
 token
 ``` 
 
@@ -86,7 +86,7 @@ kubectl -n openfaas-fn describe deployment gofast
 
 Create OpenFaaS CRD:
 ```bash
-$ kubectl apply -f artifacts/o6s-crd.yaml
+$ kubectl apply -f artifacts/operator-crd.yaml
 ```
 
 Start OpenFaaS controller (assumes you have a working kubeconfig on the machine):

--- a/artifacts/operator-amd64.yaml
+++ b/artifacts/operator-amd64.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: openfaas-operator
       containers:
       - name: gateway
-        image: functions/gateway:0.7.8-rc1
+        image: functions/gateway:0.8.2
         imagePullPolicy: Always
         env:
         - name: functions_provider_url
@@ -43,7 +43,7 @@ spec:
           limits:
             memory: 512Mi
       - name: operator
-        image: functions/openfaas-operator:0.6.0
+        image: functions/openfaas-operator:0.6.2
         imagePullPolicy: Always
         command:
           - ./openfaas-operator

--- a/artifacts/operator-armhf.yaml
+++ b/artifacts/operator-armhf.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: openfaas-operator
       containers:
       - name: gateway
-        image: functions/gateway:0.7.3-armhf
+        image: functions/gateway:0.7.8-armhf
         imagePullPolicy: Always
         env:
         - name: functions_provider_url
@@ -33,7 +33,7 @@ spec:
           limits:
             memory: 100Mi
       - name: operator
-        image: functions/openfaas-operator:arm
+        image: functions/openfaas-operator:0.6.2-armhf
         imagePullPolicy: Always
         command:
           - ./openfaas-operator

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -299,6 +299,9 @@ func (c *Controller) syncHandler(key string) error {
 		}
 
 		deployment, err = c.kubeclientset.AppsV1beta2().Deployments(function.Namespace).Update(newDeployment(function, existingSecrets))
+		if err != nil {
+			glog.Errorf("Updating deployment for '%s' failed: %v", function.Spec.Name, err)
+		}
 	}
 
 	// If an error occurs during Update, we'll requeue the item so we can

--- a/pkg/controller/deployment.go
+++ b/pkg/controller/deployment.go
@@ -158,14 +158,14 @@ func deploymentNeedsUpdate(function *faasv1alpha1.Function, deployment *appsv1be
 	needsUpdate := false
 
 	if function.Spec.Replicas != nil && *function.Spec.Replicas != *deployment.Spec.Replicas {
-		glog.V(4).Infof("Function %s replica count changed from %d to %d",
+		glog.V(2).Infof("Function %s replica count changed from %d to %d",
 			function.Spec.Name, *deployment.Spec.Replicas, *function.Spec.Replicas)
 		needsUpdate = true
 	}
 
 	currentImage := deployment.Spec.Template.Spec.Containers[0].Image
 	if function.Spec.Image != deployment.Spec.Template.Spec.Containers[0].Image {
-		glog.V(4).Infof("Function %s image changed from %d to %d",
+		glog.V(2).Infof("Function %s image changed from %d to %d",
 			function.Spec.Name, currentImage, function.Spec.Image)
 		needsUpdate = true
 	}
@@ -173,7 +173,7 @@ func deploymentNeedsUpdate(function *faasv1alpha1.Function, deployment *appsv1be
 	currentEnv := deployment.Spec.Template.Spec.Containers[0].Env
 	funcEnv := makeEnvVars(function)
 	if envVarsNotEqual(currentEnv, funcEnv) {
-		glog.V(4).Infof("Function %s envVars have changed",
+		glog.V(2).Infof("Function %s envVars have changed",
 			function.Spec.Name)
 		needsUpdate = true
 	}
@@ -181,13 +181,13 @@ func deploymentNeedsUpdate(function *faasv1alpha1.Function, deployment *appsv1be
 	currentLabels := deployment.Spec.Template.Labels
 	funcLabels := makeLabels(function)
 	if labelsNotEqual(currentLabels, funcLabels) {
-		glog.V(4).Infof("Function %s labels have changed",
+		glog.V(2).Infof("Function %s labels have changed",
 			function.Spec.Name)
 		needsUpdate = true
 	}
 
 	if secretsNotEqual(function.Spec.Secrets, deployment.Spec.Template.Spec.Volumes) {
-		glog.V(4).Infof("Function %s secrets have changed",
+		glog.V(2).Infof("Function %s secrets have changed",
 			function.Spec.Name)
 		needsUpdate = true
 	}

--- a/pkg/controller/deployment.go
+++ b/pkg/controller/deployment.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // newDeployment creates a new Deployment for a Function resource. It also sets
@@ -41,6 +42,19 @@ func newDeployment(function *faasv1alpha1.Function, existingSecrets map[string]*
 		},
 		Spec: appsv1beta2.DeploymentSpec{
 			Replicas: function.Spec.Replicas,
+			Strategy: appsv1beta2.DeploymentStrategy{
+				Type: appsv1beta2.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1beta2.RollingUpdateDeployment{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: int32(0),
+					},
+					MaxSurge: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: int32(1),
+					},
+				},
+			},
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app":        function.Spec.Name,


### PR DESCRIPTION
This PR does the following:

* fix ClusterIP creation race condition when multiple operator instances are running
* improve logging (deployment update errors, service creation errors)
* set deployment strategy to max unavailable 0 (ensure no downtime during a rolling update)
* update the gateway and operator versions in the deploy manifests
* update readme to reflect the secrets path change

All changes have been tested on GKE 1.10