### PR TITLE
Rename CRD group to openfaas.com Part2

### DIFF
--- a/artifacts/operator-amd64.yaml
+++ b/artifacts/operator-amd64.yaml
@@ -43,7 +43,7 @@ spec:
           limits:
             memory: 512Mi
       - name: operator
-        image: functions/openfaas-operator:0.7.0
+        image: functions/openfaas-operator:0.7.1
         imagePullPolicy: Always
         command:
           - ./openfaas-operator

--- a/artifacts/operator-armhf.yaml
+++ b/artifacts/operator-armhf.yaml
@@ -33,7 +33,7 @@ spec:
           limits:
             memory: 100Mi
       - name: operator
-        image: functions/openfaas-operator:0.7.0-armhf
+        image: functions/openfaas-operator:0.7.1-armhf
         imagePullPolicy: Always
         command:
           - ./openfaas-operator

--- a/artifacts/operator-rbac.yaml
+++ b/artifacts/operator-rbac.yaml
@@ -10,7 +10,7 @@ kind: ClusterRole
 metadata:
   name: openfaas-operator
 rules:
-- apiGroups: ["o6s.io"]
+- apiGroups: ["openfaas.com"]
   resources: ["functions"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -20,14 +20,14 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	faasv1alpha1 "github.com/openfaas-incubator/openfaas-operator/pkg/apis/openfaas/v1alpha2"
+	faasv1 "github.com/openfaas-incubator/openfaas-operator/pkg/apis/openfaas/v1alpha2"
 	clientset "github.com/openfaas-incubator/openfaas-operator/pkg/client/clientset/versioned"
 	faasscheme "github.com/openfaas-incubator/openfaas-operator/pkg/client/clientset/versioned/scheme"
 	informers "github.com/openfaas-incubator/openfaas-operator/pkg/client/informers/externalversions"
 	listers "github.com/openfaas-incubator/openfaas-operator/pkg/client/listers/openfaas/v1alpha2"
 )
 
-const controllerAgentName = "faas-k8s"
+const controllerAgentName = "openfaas-operator"
 const faasKind = "Function"
 const functionPort = 8080
 
@@ -322,7 +322,7 @@ func (c *Controller) syncHandler(key string) error {
 	return nil
 }
 
-func (c *Controller) updateFunctionStatus(function *faasv1alpha1.Function, deployment *appsv1beta2.Deployment) error {
+func (c *Controller) updateFunctionStatus(function *faasv1.Function, deployment *appsv1beta2.Deployment) error {
 	// NEVER modify objects from the store. It's a read-only, local cache.
 	// You can use DeepCopy() to make a deep copy of original object and modify this copy
 	// Or create a copy manually for better performance

--- a/pkg/controller/deployment.go
+++ b/pkg/controller/deployment.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	faasv1alpha1 "github.com/openfaas-incubator/openfaas-operator/pkg/apis/openfaas/v1alpha2"
+	faasv1 "github.com/openfaas-incubator/openfaas-operator/pkg/apis/openfaas/v1alpha2"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +16,7 @@ import (
 // newDeployment creates a new Deployment for a Function resource. It also sets
 // the appropriate OwnerReferences on the resource so handleObject can discover
 // the Function resource that 'owns' it.
-func newDeployment(function *faasv1alpha1.Function, existingSecrets map[string]*corev1.Secret) *appsv1beta2.Deployment {
+func newDeployment(function *faasv1.Function, existingSecrets map[string]*corev1.Secret) *appsv1beta2.Deployment {
 	envVars := makeEnvVars(function)
 	labels := makeLabels(function)
 	nodeSelector := makeNodeSelector(function.Spec.Constraints)
@@ -34,8 +34,8 @@ func newDeployment(function *faasv1alpha1.Function, existingSecrets map[string]*
 			Namespace: function.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(function, schema.GroupVersionKind{
-					Group:   faasv1alpha1.SchemeGroupVersion.Group,
-					Version: faasv1alpha1.SchemeGroupVersion.Version,
+					Group:   faasv1.SchemeGroupVersion.Group,
+					Version: faasv1.SchemeGroupVersion.Version,
 					Kind:    faasKind,
 				}),
 			},
@@ -96,7 +96,7 @@ func newDeployment(function *faasv1alpha1.Function, existingSecrets map[string]*
 	return deploymentSpec
 }
 
-func makeEnvVars(function *faasv1alpha1.Function) []corev1.EnvVar {
+func makeEnvVars(function *faasv1.Function) []corev1.EnvVar {
 	envVars := []corev1.EnvVar{}
 
 	if len(function.Spec.Handler) > 0 {
@@ -118,7 +118,7 @@ func makeEnvVars(function *faasv1alpha1.Function) []corev1.EnvVar {
 	return envVars
 }
 
-func makeLabels(function *faasv1alpha1.Function) map[string]string {
+func makeLabels(function *faasv1.Function) map[string]string {
 	labels := map[string]string{
 		"faas_function": function.Spec.Name,
 		"app":           function.Spec.Name,
@@ -168,7 +168,7 @@ func makeNodeSelector(constraints []string) map[string]string {
 }
 
 // deploymentNeedsUpdate determines if the function spec is different from the deployment spec
-func deploymentNeedsUpdate(function *faasv1alpha1.Function, deployment *appsv1beta2.Deployment) bool {
+func deploymentNeedsUpdate(function *faasv1.Function, deployment *appsv1beta2.Deployment) bool {
 	needsUpdate := false
 
 	if function.Spec.Replicas != nil && *function.Spec.Replicas != *deployment.Spec.Replicas {

--- a/pkg/controller/resources.go
+++ b/pkg/controller/resources.go
@@ -1,13 +1,13 @@
 package controller
 
 import (
-	faasv1alpha1 "github.com/openfaas-incubator/openfaas-operator/pkg/apis/openfaas/v1alpha2"
+	faasv1 "github.com/openfaas-incubator/openfaas-operator/pkg/apis/openfaas/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // makeResources creates deployment resource limits and requests requirements from function specs
-func makeResources(function *faasv1alpha1.Function) (*corev1.ResourceRequirements, error) {
+func makeResources(function *faasv1.Function) (*corev1.ResourceRequirements, error) {
 	resources := &corev1.ResourceRequirements{
 		Limits:   corev1.ResourceList{},
 		Requests: corev1.ResourceList{},

--- a/pkg/controller/secrets.go
+++ b/pkg/controller/secrets.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"fmt"
 
-	faasv1alpha1 "github.com/openfaas-incubator/openfaas-operator/pkg/apis/openfaas/v1alpha2"
+	faasv1 "github.com/openfaas-incubator/openfaas-operator/pkg/apis/openfaas/v1alpha2"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -16,7 +16,7 @@ const (
 // in the kubernetes cluster.  For each requested secret, we inspect the type and add it to the
 // deployment spec as appropriate: secrets with type `SecretTypeDockercfg` are added as ImagePullSecrets
 // all other secrets are mounted as files in the deployments containers.
-func UpdateSecrets(function *faasv1alpha1.Function, deployment *appsv1beta2.Deployment, existingSecrets map[string]*corev1.Secret) error {
+func UpdateSecrets(function *faasv1.Function, deployment *appsv1beta2.Deployment, existingSecrets map[string]*corev1.Secret) error {
 	// Add / reference pre-existing secrets within Kubernetes
 	secretVolumeProjections := []corev1.VolumeProjection{}
 

--- a/pkg/controller/secrets_test.go
+++ b/pkg/controller/secrets_test.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	faasv1alpha1 "github.com/openfaas-incubator/openfaas-operator/pkg/apis/openfaas/v1alpha2"
+	faasv1 "github.com/openfaas-incubator/openfaas-operator/pkg/apis/openfaas/v1alpha2"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func Test_UpdateSecrets_DoesNotAddVolumeIfRequestSecretsIsNil(t *testing.T) {
-	request := &faasv1alpha1.Function{
-		Spec: faasv1alpha1.FunctionSpec{
+	request := &faasv1.Function{
+		Spec: faasv1.FunctionSpec{
 			Name:    "testfunc",
 			Secrets: nil,
 		},
@@ -42,8 +42,8 @@ func Test_UpdateSecrets_DoesNotAddVolumeIfRequestSecretsIsNil(t *testing.T) {
 }
 
 func Test_UpdateSecrets_DoesNotAddVolumeIfRequestSecretsIsEmpty(t *testing.T) {
-	request := &faasv1alpha1.Function{
-		Spec: faasv1alpha1.FunctionSpec{
+	request := &faasv1.Function{
+		Spec: faasv1.FunctionSpec{
 			Name:    "testfunc",
 			Secrets: []string{},
 		},
@@ -75,8 +75,8 @@ func Test_UpdateSecrets_DoesNotAddVolumeIfRequestSecretsIsEmpty(t *testing.T) {
 
 func Test_UpdateSecrets_RemovesAllCopiesOfExitingSecretsVolumes(t *testing.T) {
 	volumeName := "testfunc-projected-secrets"
-	request := &faasv1alpha1.Function{
-		Spec: faasv1alpha1.FunctionSpec{
+	request := &faasv1.Function{
+		Spec: faasv1.FunctionSpec{
 			Name:    "testfunc",
 			Secrets: []string{},
 		},
@@ -126,8 +126,8 @@ func Test_UpdateSecrets_RemovesAllCopiesOfExitingSecretsVolumes(t *testing.T) {
 }
 
 func Test_UpdateSecrets_AddNewSecretVolume(t *testing.T) {
-	request := &faasv1alpha1.Function{
-		Spec: faasv1alpha1.FunctionSpec{
+	request := &faasv1.Function{
+		Spec: faasv1.FunctionSpec{
 			Name:    "testfunc",
 			Secrets: []string{"pullsecret", "testsecret"},
 		},
@@ -158,8 +158,8 @@ func Test_UpdateSecrets_AddNewSecretVolume(t *testing.T) {
 }
 
 func Test_UpdateSecrets_ReplacesPreviousSecretMountWithNewMount(t *testing.T) {
-	request := &faasv1alpha1.Function{
-		Spec: faasv1alpha1.FunctionSpec{
+	request := &faasv1.Function{
+		Spec: faasv1.FunctionSpec{
 			Name:    "testfunc",
 			Secrets: []string{"pullsecret", "testsecret"},
 		},
@@ -197,8 +197,8 @@ func Test_UpdateSecrets_ReplacesPreviousSecretMountWithNewMount(t *testing.T) {
 }
 
 func Test_UpdateSecrets_RemovesSecretsVolumeIfRequestSecretsIsEmptyOrNil(t *testing.T) {
-	request := &faasv1alpha1.Function{
-		Spec: faasv1alpha1.FunctionSpec{
+	request := &faasv1.Function{
+		Spec: faasv1.FunctionSpec{
 			Name:    "testfunc",
 			Secrets: []string{"pullsecret", "testsecret"},
 		},
@@ -226,8 +226,8 @@ func Test_UpdateSecrets_RemovesSecretsVolumeIfRequestSecretsIsEmptyOrNil(t *test
 
 	validateNewSecretVolumesAndMounts(t, deployment)
 
-	request = &faasv1alpha1.Function{
-		Spec: faasv1alpha1.FunctionSpec{
+	request = &faasv1.Function{
+		Spec: faasv1.FunctionSpec{
 			Name:    "testfunc",
 			Secrets: []string{},
 		},

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -6,13 +6,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	faasv1alpha1 "github.com/openfaas-incubator/openfaas-operator/pkg/apis/openfaas/v1alpha2"
+	faasv1 "github.com/openfaas-incubator/openfaas-operator/pkg/apis/openfaas/v1alpha2"
 )
 
 // newService creates a new ClusterIP Service for a Function resource. It also sets
 // the appropriate OwnerReferences on the resource so handleObject can discover
 // the Function resource that 'owns' it.
-func newService(function *faasv1alpha1.Function) *corev1.Service {
+func newService(function *faasv1.Function) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        function.Spec.Name,
@@ -20,8 +20,8 @@ func newService(function *faasv1alpha1.Function) *corev1.Service {
 			Annotations: map[string]string{"prometheus.io.scrape": "false"},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(function, schema.GroupVersionKind{
-					Group:   faasv1alpha1.SchemeGroupVersion.Group,
-					Version: faasv1alpha1.SchemeGroupVersion.Version,
+					Group:   faasv1.SchemeGroupVersion.Group,
+					Version: faasv1.SchemeGroupVersion.Version,
 					Kind:    faasKind,
 				}),
 			},


### PR DESCRIPTION
This PR does the following:

- rename CRD group to openfaas.com in RBAC
- rename imports from `faasv1alpha1` to `faasv1`
- rename the Kubernetes event owner from `faas-k8s` to `openfaas-operator`
- bump image version to `openfaas-operator:0.7.1`
- CRUD operations were tested with kubectl and Gateway UI
- tested on GKE 1.10 with stefanprodan/openfaas-operator:0.7.1