### PR TITLE
Push image to openfaas repo on Quay.io and Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,8 @@ after_success:
       docker tag openfaas/openfaas-operator:latest openfaas/openfaas-operator:$TRAVIS_TAG;
       echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
       docker push openfaas/openfaas-operator:$TRAVIS_TAG;
+
+      docker tag openfaas/openfaas-operator:latest quay.io/openfaas/openfaas-operator:$TRAVIS_TAG;
+      echo $QUAY_PASSWORD | docker login -u=$QUAY_USERNAME --password-stdin quay.io;
+      docker push quay.io/openfaas/openfaas-operator:$TRAVIS_TAG;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
 
 after_success:
   - if [ ! -s "$TRAVIS_TAG" ] ; then
-      docker tag functions/openfaas-operator:latest functions/openfaas-operator:$TRAVIS_TAG;
+      docker tag openfaas/openfaas-operator:latest openfaas/openfaas-operator:$TRAVIS_TAG;
       echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
-      docker push functions/openfaas-operator:$TRAVIS_TAG;
+      docker push openfaas/openfaas-operator:$TRAVIS_TAG;
     fi

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 TAG?=latest
 
 build:
-	docker build -t functions/openfaas-operator:$(TAG) . -f Dockerfile
+	docker build -t openfaas/openfaas-operator:$(TAG) . -f Dockerfile
 
 build-armhf:
-	docker build -t functions/openfaas-operator:$(TAG)-armhf . -f Dockerfile.armhf
+	docker build -t openfaas/openfaas-operator:$(TAG)-armhf . -f Dockerfile.armhf
 
 push:
-	docker push functions/openfaas-operator:$(TAG)
+	docker push openfaas/openfaas-operator:$(TAG)
 
 test:
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -8,27 +8,23 @@ OpenFaaS Kubernetes Operator
 
 ### Deploy
 
-Deploy OpenFaaS with faas-netes:
+Deploy OpenFaaS Operator with Helm:
 
 ```bash
-git clone https://github.com/openfaas/faas-netes
-cd faas-netes
-kubectl apply -f ./namespaces.yml,./yaml
+# create OpenFaaS namespaces
+kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
+
+# add OpenFaaS Helm repo
+helm repo add openfaas https://openfaas.github.io/faas-netes/
+
+# get latest chart version and install
+helm repo update && helm upgrade openfaas --install openfaas/openfaas \
+    --namespace openfaas  \
+    --set functionNamespace=openfaas-fn \
+    --set operator.create=true
 ```
 
-Deploy the Gateway with openfaas-operator sidecar in `openfaas` namespace:
-
-```bash
-# CRD
-kubectl apply -f artifacts/operator-crd.yaml
-# RBAC
-kubectl apply -f artifacts/operator-rbac.yaml
-# Deployment (use operator-armhf.yaml for faas-netes/yaml_armhf)
-kubectl apply -f artifacts/operator-amd64.yaml
-# Delete faas-netes
-kubectl -n openfaas delete deployment faas-netesd
-kubectl -n openfaas delete svc faas-netesd
-```
+If you are upgrading from faas-netes you need to remove all functions and redeploy them after installing the operator.
 
 Deploy a function with kubectl:
 


### PR DESCRIPTION
This PR does the following:
- publish the Docker image to `openfaas` repository on Docker Hub and Quay.io
- update the readme with the official Helm install instructions 

Ref https://github.com/openfaas/faas/issues/741
Fix #28