### PR TITLE
Move openfaas-operator from functions/ to openfaas/ ns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,12 @@ script:
   - make build
 
 after_success:
+  - if [ -z $DOCKER_NS ] ; then
+      export DOCKER_NS=openfaas;
+    fi
+
   - if [ ! -s "$TRAVIS_TAG" ] ; then
-      docker tag functions/openfaas-operator:latest functions/openfaas-operator:$TRAVIS_TAG;
+      docker tag $DOCKER_NS/openfaas-operator:latest $DOCKER_NS/openfaas-operator:$TRAVIS_TAG;
       echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
-      docker push functions/openfaas-operator:$TRAVIS_TAG;
+      docker push $DOCKER_NS/openfaas-operator:$TRAVIS_TAG;
     fi

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 TAG?=latest
 
 build:
-	docker build -t functions/openfaas-operator:$(TAG) . -f Dockerfile
+	docker build -t openfaas/openfaas-operator:$(TAG) . -f Dockerfile
 
 build-armhf:
-	docker build -t functions/openfaas-operator:$(TAG)-armhf . -f Dockerfile.armhf
+	docker build -t openfaas/openfaas-operator:$(TAG)-armhf . -f Dockerfile.armhf
 
 push:
-	docker push functions/openfaas-operator:$(TAG)
+	docker push openfaas/openfaas-operator:$(TAG)
 
 test:
 	go test ./...


### PR DESCRIPTION
This moves openfaas-operator to a better name for images and also gives free image-scanning  and  gives  more  confidence  to  users  that components  ship  regularly  and  makes  any  vulnerabilities  in components clear

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Resolves [#741](https://github.com/openfaas/faas/issues/741)

Tested with local build
