### PR TITLE
Make the operator work with Role instead of Cluster Role

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Status](https://travis-ci.org/openfaas-incubator/openfaas-operator.svg?branch=master)](https://travis-ci.org/openfaas-incubator/openfaas-operator) [![GoDoc](https://godoc.org/github.com/openfaas-incubator/openfaas-operator?status.svg)](https://godoc.org/github.com/openfaas-incubator/openfaas-operator) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![OpenFaaS](https://img.shields.io/badge/openfaas-serverless-blue.svg)](https://www.openfaas.com)
 
-OpenFaaS Kubernetes Operator
+OpenFaaS Operator for Kubernetes 1.9 or newer
 
 ### Deploy
 

--- a/artifacts/operator-rbac.yaml
+++ b/artifacts/operator-rbac.yaml
@@ -6,9 +6,10 @@ metadata:
   namespace: openfaas
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
-  name: openfaas-operator
+  name: openfaas-operator-rw
+  namespace: openfaas-fn
 rules:
 - apiGroups: ["openfaas.com"]
   resources: ["functions"]
@@ -16,26 +17,6 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: openfaas-operator
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: openfaas-operator
-subjects:
-- kind: ServiceAccount
-  name: openfaas-operator
-  namespace: openfaas
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: openfaas-operator-rw
-  namespace: openfaas-fn
-rules:
 - apiGroups: [""]
   resources: ["services"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/main.go
+++ b/main.go
@@ -59,9 +59,12 @@ func main() {
 	}
 
 	defaultResync := time.Second * 30
-	informerOpt := kubeinformers.WithNamespace(functionNamespace)
-	kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResync, informerOpt)
-	faasInformerFactory := informers.NewSharedInformerFactory(faasClient, defaultResync)
+
+	kubeInformerOpt := kubeinformers.WithNamespace(functionNamespace)
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResync, kubeInformerOpt)
+
+	faasInformerOpt := informers.WithNamespace(functionNamespace)
+	faasInformerFactory := informers.NewSharedInformerFactoryWithOptions(faasClient, defaultResync, faasInformerOpt)
 
 	ctrl := controller.NewController(kubeClient, faasClient, kubeInformerFactory, faasInformerFactory)
 


### PR DESCRIPTION
- restrict the kubernetes informers to the functions namespace
- remove the cluster role from RBAC
- mention in the readme the minimum supported Kubernetes version
- tested on GKE 1.10 with the new RBAC
- fix #29

Signed-off-by: Stefan Prodan <stefan.prodan@gmail.com>