### PR TITLE
Handle replica count query failures

### DIFF
--- a/pkg/server/list.go
+++ b/pkg/server/list.go
@@ -26,9 +26,7 @@ func makeListHandler(namespace string, client clientset.Interface, kube kubernet
 		for _, item := range res.Items {
 			desiredReplicas, availableReplicas, err := getReplicas(item.Spec.Name, namespace, kube)
 			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				glog.Errorf("Function listing getReplicas error: %v", err)
-				return
+				glog.Warningf("Function listing getReplicas error: %v", err)
 			}
 
 			function := requests.Function{

--- a/pkg/server/replicas.go
+++ b/pkg/server/replicas.go
@@ -28,9 +28,7 @@ func makeReplicaReader(namespace string, client clientset.Interface, kube kubern
 
 		desiredReplicas, availableReplicas, err := getReplicas(functionName, namespace, kube)
 		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			glog.Errorf("Function replica reader error: %v", err)
-			return
+			glog.Warningf("Function replica reader error: %v", err)
 		}
 
 		result := &requests.Function{


### PR DESCRIPTION
This PR fixes #41 

- log warning if replica count query fails
- do not return HTTP 500 if a function deployment is not ready
- return 0 replicas if a function deployment is not found
- tested on GKE 1.10 with an unknown image pull secret
