### PR TITLE
Add named port to functions

### DIFF
--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -31,6 +31,7 @@ func newService(function *faasv1.Function) *corev1.Service {
 			Selector: map[string]string{"faas_function": function.Spec.Name},
 			Ports: []corev1.ServicePort{
 				{
+					Name:     "http",
 					Protocol: corev1.ProtocolTCP,
 					Port:     functionPort,
 					TargetPort: intstr.IntOrString{


### PR DESCRIPTION
This change allows additional metadata to be sourced from the
Kubenetes service about the port exposed at the function level.

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>