### PR TITLE
Fixed validation of resources

### DIFF
--- a/pkg/apis/openfaas/v1alpha2/types.go
+++ b/pkg/apis/openfaas/v1alpha2/types.go
@@ -35,8 +35,8 @@ type FunctionSpec struct {
 
 // FunctionResources is used to set CPU and memory limits and requests
 type FunctionResources struct {
-	Memory string `json:"memory"`
-	CPU    string `json:"cpu"`
+	Memory string `json:"memory,omitempty"`
+	CPU    string `json:"cpu,omitempty"`
 }
 
 // FunctionStatus is the status for a Function resource


### PR DESCRIPTION
Added omitempty to FunctionResources (Memory and CPU)

Fixes: https://github.com/openfaas-incubator/openfaas-operator/issues/54

Signed-off-by: Bart Smykla <bsmykla@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
- I deployed a function without limits
- I deployed a function with only CPU limit
- I deployed a function with only memory limit
- I deployed a function with both CPU and memory limits

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] I have run the [certifier](https://github.com/openfaas/certifier)
Results:
```
=== RUN   Test_Access_Secret
=== RUN   Test_Access_Secret/Empty_QueryString
--- PASS: Test_Access_Secret (27.81s)
    --- PASS: Test_Access_Secret/Empty_QueryString (27.51s)
        verify.go:71: [1/30] Got correct response: 200 - https://gateway/function/test-secret
=== RUN   Test_Deploy_Stronghash
--- PASS: Test_Deploy_Stronghash (0.39s)
=== RUN   Test_Deploy_PassingCustomEnvVars_AndQueryString
=== RUN   Test_Deploy_PassingCustomEnvVars_AndQueryString/Empty_QueryString
=== RUN   Test_Deploy_PassingCustomEnvVars_AndQueryString/Populated_QueryString
--- PASS: Test_Deploy_PassingCustomEnvVars_AndQueryString (62.59s)
    --- PASS: Test_Deploy_PassingCustomEnvVars_AndQueryString/Empty_QueryString (62.15s)
        verify.go:52: [1/30] Bad response want: [200], got: 504 - https://gateway/function/env-test
        verify.go:71: [2/30] Got correct response: 200 - https://gateway/function/env-test
    --- PASS: Test_Deploy_PassingCustomEnvVars_AndQueryString/Populated_QueryString (0.02s)
        verify.go:71: [1/30] Got correct response: 200 - https://gateway/function/env-test?testing=1
=== RUN   Test_Deploy_WithLabels
--- PASS: Test_Deploy_WithLabels (67.59s)
    verify.go:52: [1/30] Bad response want: [200], got: 504 - https://gateway/function/env-test-labels
    verify.go:71: [2/30] Got correct response: 200 - https://gateway/function/env-test-labels
=== RUN   Test_Deploy_WithAnnotations
--- PASS: Test_Deploy_WithAnnotations (76.26s)
    verify.go:52: [1/30] Bad response want: [200], got: 504 - https://gateway/function/env-test-annotations
    verify.go:71: [2/30] Got correct response: 200 - https://gateway/function/env-test-annotations
=== RUN   Test_InvokeNotFound
--- PASS: Test_InvokeNotFound (0.16s)
    verify.go:71: [1/30] Got correct response: 404 - https://gateway/function/notfound
=== RUN   Test_Invoke_With_Supported_Verbs
=== RUN   Test_Invoke_With_Supported_Verbs/GET
=== RUN   Test_Invoke_With_Supported_Verbs/POST
=== RUN   Test_Invoke_With_Supported_Verbs/PUT
=== RUN   Test_Invoke_With_Supported_Verbs/PATCH
=== RUN   Test_Invoke_With_Supported_Verbs/DELETE
--- PASS: Test_Invoke_With_Supported_Verbs (132.77s)
    --- PASS: Test_Invoke_With_Supported_Verbs/GET (131.58s)
        verify.go:71: [1/30] Got correct response: 200 - https://gateway/function/env-test-verbs
    --- PASS: Test_Invoke_With_Supported_Verbs/POST (0.65s)
        verify.go:71: [1/30] Got correct response: 200 - https://gateway/function/env-test-verbs
    --- PASS: Test_Invoke_With_Supported_Verbs/PUT (0.03s)
        verify.go:71: [1/30] Got correct response: 200 - https://gateway/function/env-test-verbs
    --- PASS: Test_Invoke_With_Supported_Verbs/PATCH (0.04s)
        verify.go:71: [1/30] Got correct response: 200 - https://gateway/function/env-test-verbs
    --- PASS: Test_Invoke_With_Supported_Verbs/DELETE (0.04s)
        verify.go:71: [1/30] Got correct response: 200 - https://gateway/function/env-test-verbs
PASS
ok  	github.com/openfaas/certifier/tests	367.582s
      368.61 real         0.75 user         0.59 sys
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Impact to existing users
I don't think that there is any impact, because in situation where there was only one of the limits it just didn't work, so I don't think that it affects current users
<!-- What must existing users do to adopt this change? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
