### PR TITLE
Bundle golang to 1.10 and alpine to 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9
+FROM golang:1.10
 
 RUN mkdir -p /go/src/github.com/openfaas-incubator/openfaas-operator/
 
@@ -14,7 +14,7 @@ RUN gofmt -l -d $(find . -type f -name '*.go' -not -path "./vendor/*") && \
   -X github.com/openfaas-incubator/openfaas-operator/pkg/version.SHA=${GIT_COMMIT}" \
   -a -installsuffix cgo -o openfaas-operator .
 
-FROM alpine:3.7
+FROM alpine:3.8
 
 RUN addgroup -S app \
     && adduser -S -g app app \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM golang:1.9
+FROM golang:1.10
 
 RUN mkdir -p /go/src/github.com/openfaas-incubator/openfaas-operator/
 
@@ -14,7 +14,7 @@ RUN gofmt -l -d $(find . -type f -name '*.go' -not -path "./vendor/*") && \
   -X github.com/openfaas-incubator/openfaas-operator/pkg/version.SHA=${GIT_COMMIT}" \
   -a -installsuffix cgo -o openfaas-operator .
 
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN addgroup -S app \
     && adduser -S -g app app \


### PR DESCRIPTION
## Description
- Bump the golang docker base image to the 1.10 tag, this is currently
golang 1.10.5
- Bumpe alpine docker base image to 3.8

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #57 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] I have run the [certifier](https://github.com/openfaas/certifier)

I tried running the certifier, but got a nil pointer error

```go
=== RUN   Test_Access_Secret
=== RUN   Test_Access_Secret/Empty_QueryString
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x124e679]

goroutine 9 [running]:
testing.tRunner.func1(0xc42011a1e0)
	/usr/local/Cellar/go/1.10.2/libexec/src/testing/testing.go:742 +0x29d
panic(0x1297d40, 0x146e1e0)
	/usr/local/Cellar/go/1.10.2/libexec/src/runtime/panic.go:502 +0x229
github.com/openfaas/certifier/tests.invokeWithVerb(0xc42011a1e0, 0x12ec4bd, 0x4, 0x12ede6d, 0xb, 0x0, 0x0, 0xc420018948, 0x1, 0x1, ...)
	/Users/lucasroesler/Code/go/src/github.com/openfaas/certifier/tests/verify.go:36 +0xe9
github.com/openfaas/certifier/tests.invoke(0xc42011a1e0, 0x12ede6d, 0xb, 0x0, 0x0, 0xc420018948, 0x1, 0x1, 0xc420018960, 0x10cb83d, ...)
	/Users/lucasroesler/Code/go/src/github.com/openfaas/certifier/tests/verify.go:11 +0x9f
github.com/openfaas/certifier/tests.Test_Access_Secret.func1(0xc42011a1e0)
	/Users/lucasroesler/Code/go/src/github.com/openfaas/certifier/tests/deploy_test.go:42 +0xc5
testing.tRunner(0xc42011a1e0, 0xc4201026e0)
	/usr/local/Cellar/go/1.10.2/libexec/src/testing/testing.go:777 +0xd0
created by testing.(*T).Run
	/usr/local/Cellar/go/1.10.2/libexec/src/testing/testing.go:824 +0x2e0
FAIL	github.com/openfaas/certifier/tests	69.160s
```

I manually tested the change using the `docker-for-desktop` Kubernetes

In openfaas-operator repo

```sh
make build
```

In the faas-netes repo

```sh
kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
helm upgrade openfaas --install . \
    --namespace openfaas  \
    --set operator.create=true \
    --set operator.image=openfaas/openfaas-operator:latest \
    --set basic_auth=false \
    --set openfaasImagePullPolicy=IfNotPresent \
    --set functionNamespace=openfaas-fn
```

In openfaas-operator repo

```sh
kubectl -n openfaas-fn apply -f ./artifacts/nodeinfo.yaml
sleep 5 && curl http://localhost:31112/function/nodeinfo
```

Also, in the browser go to http://localhost:31112/ui/ and see the `nodeinfo` function is running and test it

Now, delete the function 

```sh
kubectl -n openfaas-fn delete function nodeinfo
```

Check that the ui updates accordingly.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Impact to existing users
<!-- What must existing users do to adopt this change? -->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
