### PR TITLE
Put imagePullPolicy into the controller structure

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -116,6 +116,7 @@ func NewController(
 		functionsSynced:   faasInformer.Informer().HasSynced,
 		workqueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Functions"),
 		recorder:          recorder,
+		imagePullPolicy:   imagePullPolicy,
 	}
 
 	glog.Info("Setting up event handlers")


### PR DESCRIPTION
Signed-off-by: Wouter Horré <wouter@zenjoy.be>

Copy the `imagePullPolicy` passed as an argument to `NewController` into the controller structure.

## Description

The `imagePullPolicy` passed as an argument to `NewController` was not put into the controller structure. The pull request fixes this issue.

## Motivation and Context

Fixes #56 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have successfully verified that this change fixes #56 by deploying this to our cluster and verifying the `imagePullPolicy` on a newly created function.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Impact to existing users
<!-- What must existing users do to adopt this change? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
