### PR TITLE
Populate serviceAccount based upon annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,25 @@ Delete secret:
 curl -d '{"name":"test"}' -X DELETE http://localhost:8081/system/secrets
 ```
 
+#### Configure the service account for your function
+
+Example service account:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-robot
+  namespace: openfaas-fn
+```
+
+Set the following in your function spec:
+
+```yaml
+annotations:
+  com.openfaas.serviceaccount: "build-robot"
+```
+
 ### Logging
 
 Verbosity levels:

--- a/pkg/controller/deployment.go
+++ b/pkg/controller/deployment.go
@@ -40,6 +40,15 @@ func newDeployment(
 
 	annotations := makeAnnotations(function)
 
+	var serviceAccount string
+
+	if function.Spec.Annotations != nil {
+		annotations := *function.Spec.Annotations
+		if val, ok := annotations["com.openfaas.serviceaccount"]; ok && len(val) > 0 {
+			serviceAccount = val
+		}
+	}
+
 	deploymentSpec := &appsv1beta2.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        function.Spec.Name,
@@ -99,6 +108,10 @@ func newDeployment(
 				},
 			},
 		},
+	}
+
+	if len(serviceAccount) > 0 {
+		deploymentSpec.Spec.Template.Spec.ServiceAccountName = serviceAccount
 	}
 
 	configureReadOnlyRootFilesystem(function, deploymentSpec)


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The com.openfaas.serviceaccount annotation is used from the
function spec to assign a serviceAccount to the podSpec.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Completes https://github.com/openfaas/faas-netes/issues/409 for the Operator, but needs adding to faas-netes next.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] I have run the [certifier](https://github.com/openfaas/certifier) (yes, via CI)

Tested on Kind with Kubernetes 1.13. First by setting the value
as build-robot (as per README.md) and seeing it applied on the
podSpec, then by removing the annotation and seeing it go back
to "default".

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Impact to existing users
<!-- What must existing users do to adopt this change? -->

No impact to existing users, to adopt users can now set the annotation on the function CRD spec.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
