### PR TITLE
 Add support for HTTP probes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -201,6 +201,14 @@
   version = "0.9.14"
 
 [[projects]]
+  digest = "1:21fd9c80efa30670d802551f0d2949a0c06fadb6764d1f1b65615f52bad315ea"
+  name = "github.com/openfaas/faas-netes"
+  packages = ["types"]
+  pruneopts = "UT"
+  revision = "aa7ebfc35f66fd881fa9fc26de1cd94f4e65731f"
+  version = "0.7.3"
+
+[[projects]]
   digest = "1:51ce680938533385fd69725839e0e419d6e100308897341ff93151571d73cd7f"
   name = "github.com/openfaas/faas-provider"
   packages = [
@@ -729,6 +737,7 @@
   input-imports = [
     "github.com/google/go-cmp/cmp",
     "github.com/gorilla/mux",
+    "github.com/openfaas/faas-netes/types",
     "github.com/openfaas/faas-provider",
     "github.com/openfaas/faas-provider/types",
     "github.com/openfaas/faas/gateway/requests",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,6 +39,10 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
   version = "0.9.14"
 
 [[constraint]]
+  name = "github.com/openfaas/faas-netes"
+  version = "0.7.3"
+
+[[constraint]]
   name = "github.com/prometheus/client_golang"
   version = "v0.9.2"
 

--- a/pkg/controller/probes.go
+++ b/pkg/controller/probes.go
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	"github.com/openfaas/faas-netes/types"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"os"
+	"path/filepath"
+)
+
+type FunctionProbes struct {
+	Liveness  *corev1.Probe
+	Readiness *corev1.Probe
+}
+
+// makeProbes returns liveness and readiness configured with exec if
+// the env var http_probe is false
+func makeProbes(config types.BootstrapConfig) *FunctionProbes {
+	var handler corev1.Handler
+
+	if config.HTTPProbe {
+		handler = corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/_/health",
+				Port: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: int32(functionPort),
+				},
+			},
+		}
+	} else {
+		path := filepath.Join(os.TempDir(), ".lock")
+		handler = corev1.Handler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"cat", path},
+			},
+		}
+	}
+
+	probes := FunctionProbes{}
+	probes.Readiness = &corev1.Probe{
+		Handler:             handler,
+		InitialDelaySeconds: int32(config.ReadinessProbeInitialDelaySeconds),
+		TimeoutSeconds:      int32(config.ReadinessProbeTimeoutSeconds),
+		PeriodSeconds:       int32(config.ReadinessProbePeriodSeconds),
+		SuccessThreshold:    1,
+		FailureThreshold:    3,
+	}
+
+	probes.Liveness = &corev1.Probe{
+		Handler:             handler,
+		InitialDelaySeconds: int32(config.LivenessProbeInitialDelaySeconds),
+		TimeoutSeconds:      int32(config.LivenessProbeTimeoutSeconds),
+		PeriodSeconds:       int32(config.LivenessProbePeriodSeconds),
+		SuccessThreshold:    1,
+		FailureThreshold:    3,
+	}
+
+	return &probes
+}

--- a/pkg/controller/probes.go
+++ b/pkg/controller/probes.go
@@ -4,7 +4,6 @@ import (
 	"github.com/openfaas/faas-netes/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"os"
 	"path/filepath"
 )
 
@@ -29,7 +28,7 @@ func makeProbes(config types.BootstrapConfig) *FunctionProbes {
 			},
 		}
 	} else {
-		path := filepath.Join(os.TempDir(), ".lock")
+		path := filepath.Join("/tmp/", ".lock")
 		handler = corev1.Handler{
 			Exec: &corev1.ExecAction{
 				Command: []string{"cat", path},

--- a/pkg/controller/probes_test.go
+++ b/pkg/controller/probes_test.go
@@ -1,0 +1,39 @@
+package controller
+
+import (
+	"github.com/openfaas/faas-netes/types"
+	"testing"
+)
+
+func Test_makeProbes_useExec(t *testing.T) {
+	readConfig := types.ReadConfig{}
+	config := readConfig.Read(types.OsEnv{})
+
+	probes := makeProbes(config)
+
+	if probes.Readiness.Exec == nil {
+		t.Errorf("Readiness probe should have had exec handler")
+		t.Fail()
+	}
+	if probes.Liveness.Exec == nil {
+		t.Errorf("Liveness probe should have had exec handler")
+		t.Fail()
+	}
+}
+
+func Test_makeProbes_useHTTPProbe(t *testing.T) {
+	readConfig := types.ReadConfig{}
+	config := readConfig.Read(types.OsEnv{})
+	config.HTTPProbe = true
+
+	probes := makeProbes(config)
+
+	if probes.Readiness.HTTPGet == nil {
+		t.Errorf("Readiness probe should have had HTTPGet handler")
+		t.Fail()
+	}
+	if probes.Liveness.HTTPGet == nil {
+		t.Errorf("Liveness probe should have had HTTPGet handler")
+		t.Fail()
+	}
+}

--- a/vendor/github.com/openfaas/faas-netes/LICENSE
+++ b/vendor/github.com/openfaas/faas-netes/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Alex Ellis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/openfaas/faas-netes/types/read_config.go
+++ b/vendor/github.com/openfaas/faas-netes/types/read_config.go
@@ -1,0 +1,124 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+package types
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+// OsEnv implements interface to wrap os.Getenv
+type OsEnv struct {
+}
+
+// Getenv wraps os.Getenv
+func (OsEnv) Getenv(key string) string {
+	return os.Getenv(key)
+}
+
+// HasEnv provides interface for os.Getenv
+type HasEnv interface {
+	Getenv(key string) string
+}
+
+// ReadConfig constitutes config from env variables
+type ReadConfig struct {
+}
+
+func parseIntValue(val string, fallback int) int {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return parsedVal
+		}
+	}
+	return fallback
+}
+
+func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return time.Duration(parsedVal) * time.Second
+		}
+	}
+
+	duration, durationErr := time.ParseDuration(val)
+	if durationErr != nil {
+		return fallback
+	}
+
+	return duration
+}
+
+func parseBoolValue(val string, fallback bool) bool {
+	if len(val) > 0 {
+		return val == "true"
+	}
+	return fallback
+}
+
+func parseString(val string, fallback string) string {
+	if len(val) > 0 {
+		return val
+	}
+	return fallback
+}
+
+// Read fetches config from environmental variables.
+func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
+	cfg := BootstrapConfig{}
+
+	httpProbe := parseBoolValue(hasEnv.Getenv("http_probe"), false)
+
+	readinessProbeInitialDelaySeconds := parseIntValue(hasEnv.Getenv("readiness_probe_initial_delay_seconds"), 3)
+	readinessProbeTimeoutSeconds := parseIntValue(hasEnv.Getenv("readiness_probe_timeout_seconds"), 1)
+	readinessProbePeriodSeconds := parseIntValue(hasEnv.Getenv("readiness_probe_period_seconds"), 10)
+
+	livenessProbeInitialDelaySeconds := parseIntValue(hasEnv.Getenv("liveness_probe_initial_delay_seconds"), 3)
+	livenessProbeTimeoutSeconds := parseIntValue(hasEnv.Getenv("liveness_probe_timeout_seconds"), 1)
+	livenessProbePeriodSeconds := parseIntValue(hasEnv.Getenv("liveness_probe_period_seconds"), 10)
+
+	readTimeout := parseIntOrDurationValue(hasEnv.Getenv("read_timeout"), time.Second*10)
+	writeTimeout := parseIntOrDurationValue(hasEnv.Getenv("write_timeout"), time.Second*10)
+
+	imagePullPolicy := parseString(hasEnv.Getenv("image_pull_policy"), "Always")
+
+	cfg.ReadTimeout = readTimeout
+	cfg.WriteTimeout = writeTimeout
+
+	cfg.HTTPProbe = httpProbe
+
+	cfg.ReadinessProbeInitialDelaySeconds = readinessProbeInitialDelaySeconds
+	cfg.ReadinessProbeTimeoutSeconds = readinessProbeTimeoutSeconds
+	cfg.ReadinessProbePeriodSeconds = readinessProbePeriodSeconds
+
+	cfg.LivenessProbeInitialDelaySeconds = livenessProbeInitialDelaySeconds
+	cfg.LivenessProbeTimeoutSeconds = livenessProbeTimeoutSeconds
+	cfg.LivenessProbePeriodSeconds = livenessProbePeriodSeconds
+
+	cfg.ImagePullPolicy = imagePullPolicy
+
+	defaultTCPPort := 8080
+	cfg.Port = parseIntValue(hasEnv.Getenv("port"), defaultTCPPort)
+
+	return cfg
+}
+
+// BootstrapConfig for the process.
+type BootstrapConfig struct {
+	// HTTPProbe when set to true switches readiness and liveness probe to
+	// access /_/health over HTTP instead of accessing /tmp/.lock.
+	HTTPProbe                         bool
+	ReadinessProbeInitialDelaySeconds int
+	ReadinessProbeTimeoutSeconds      int
+	ReadinessProbePeriodSeconds       int
+	LivenessProbeInitialDelaySeconds  int
+	LivenessProbeTimeoutSeconds       int
+	LivenessProbePeriodSeconds        int
+	ReadTimeout                       time.Duration
+	WriteTimeout                      time.Duration
+	ImagePullPolicy                   string
+	Port                              int
+}

--- a/vendor/github.com/openfaas/faas-netes/types/requests.go
+++ b/vendor/github.com/openfaas/faas-netes/types/requests.go
@@ -1,0 +1,9 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package types
+
+type ScaleServiceRequest struct {
+	ServiceName string `json:"serviceName"`
+	Replicas    uint64 `json:"replicas"`
+}


### PR DESCRIPTION
Port http/exec probes from faas-netes https://github.com/openfaas/faas-netes/pull/414

## Description
- add faas-netes types package dep
- load the bootstrap config from env vars
- create probes based on http_probe var
- add tests for exec and http probes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fix: #78 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] I have run the [certifier](https://github.com/openfaas/certifier)

Tested on GKE with `http_probe` env var false/true

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Impact to existing users
<!-- What must existing users do to adopt this change? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
