### PR TITLE
Vendor faas-provier 0.9.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -209,7 +209,7 @@
   version = "0.7.3"
 
 [[projects]]
-  digest = "1:51ce680938533385fd69725839e0e419d6e100308897341ff93151571d73cd7f"
+  digest = "1:698444ab032d6e8528ae9171659941a2afea8003978c240e860936128e22a8c6"
   name = "github.com/openfaas/faas-provider"
   packages = [
     ".",
@@ -217,8 +217,8 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "220324e98f5db5aa61f02d1ab13f03e91310796c"
-  version = "0.8.1"
+  revision = "6a76a052deb12fd94b373c082963d8a8ad44d4d1"
+  version = "0.9.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,7 +32,7 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
 
 [[constraint]]
   name = "github.com/openfaas/faas-provider"
-  version = "0.8.1"
+  version = "0.9.0"
 
 [[constraint]]
   name = "github.com/openfaas/faas"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -71,7 +71,7 @@ func Start(client clientset.Interface,
 		ReplicaReader:  makeReplicaReader(functionNamespace, client, kube, deploymentLister),
 		ReplicaUpdater: makeReplicaHandler(functionNamespace, client),
 		UpdateHandler:  makeApplyHandler(functionNamespace, client),
-		Health:         makeHealthHandler(),
+		HealthHandler:  makeHealthHandler(),
 		InfoHandler:    makeInfoHandler(),
 		SecretHandler:  makeSecretHandler(functionNamespace, kube),
 	}

--- a/vendor/github.com/openfaas/faas-provider/.gitignore
+++ b/vendor/github.com/openfaas/faas-provider/.gitignore
@@ -13,4 +13,7 @@
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
 
+# Goland IDE
+.idea
+
 faas-backend

--- a/vendor/github.com/openfaas/faas-provider/README.md
+++ b/vendor/github.com/openfaas/faas-provider/README.md
@@ -1,23 +1,30 @@
 faas-provider
 ==============
 
-This is a common template or interface for you to start building your own OpenFaaS backend.
+This faas-provider can be used to write your own back-end for OpenFaaS. The Golang SDK can be vendored into your project so that you can provide a provider which is compliant and compatible with the OpenFaaS gateway.
 
-Checkout the [backends guide here](https://github.com/openfaas/faas/blob/master/guide/backends.md) before starting.
+![Conceptual diagram](docs/conceptual.png)
 
-OpenFaaS projects use the MIT License and are written in Golang. We encourage the same for external / third-party providers.
+The faas-provider provides CRUD for functions and an invoke capability. If you complete the required endpoints then you will be able to use your container orchestrator or back-end system with the existing OpenFaaS ecosystem and tooling.
 
-### How to use this code
+> See also: [backends guide](https://github.com/openfaas/faas/blob/master/guide/deprecated/backends.md)
 
-We will setup all the standard HTTP routes for you, then start listening on a given TCP port - it should be 8080.
+### Recommendations
 
-Just implement the supplied routes.
+The following is used in OpenFaaS and recommended for those seeking to build their own back-ends:
 
-For an example checkout the [server.go](https://github.com/openfaas/faas-netes/blob/master/server.go) file in the [faas-netes](https://github.com/openfaas/faas-netes) Kubernetes backend.
+* License: MIT
+* Language: Golang 
+
+### How to use this project
+
+All the required HTTP routes are configured automatically including a HTTP server on port 8080. Your task is to implement the supplied HTTP handler functions.
+
+For an example see the [server.go](https://github.com/openfaas/faas-netes/blob/master/server.go) file in the [faas-netes](https://github.com/openfaas/faas-netes) Kubernetes backend.
 
 I.e.:
 
-```golang
+```go
 	bootstrapHandlers := bootTypes.FaaSHandlers{
 		FunctionProxy:  handlers.MakeProxy(),
 		DeleteHandler:  handlers.MakeDeleteHandler(clientset),
@@ -27,6 +34,7 @@ I.e.:
 		ReplicaUpdater: handlers.MakeReplicaUpdater(clientset),
 		InfoHandler:    handlers.MakeInfoHandler(),
 	}
+
 	var port int
 	port = 8080
 	bootstrapConfig := bootTypes.FaaSConfig{
@@ -37,3 +45,7 @@ I.e.:
 
 	bootstrap.Serve(&bootstrapHandlers, &bootstrapConfig)
 ```
+
+### Need help?
+
+Join `#faas-provider` on [OpenFaaS Slack](https://docs.openfaas.com/community/)

--- a/vendor/github.com/openfaas/faas-provider/serve.go
+++ b/vendor/github.com/openfaas/faas-provider/serve.go
@@ -66,7 +66,7 @@ func Serve(handlers *types.FaaSHandlers, config *types.FaaSConfig) {
 	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/{params:.*}", handlers.FunctionProxy)
 
 	if config.EnableHealth {
-		r.HandleFunc("/healthz", handlers.Health).Methods("GET")
+		r.HandleFunc("/healthz", handlers.HealthHandler).Methods("GET")
 	}
 
 	readTimeout := config.ReadTimeout

--- a/vendor/github.com/openfaas/faas-provider/types/config.go
+++ b/vendor/github.com/openfaas/faas-provider/types/config.go
@@ -19,7 +19,7 @@ type FaaSHandlers struct {
 
 	// Optional: Update an existing function
 	UpdateHandler http.HandlerFunc
-	Health        http.HandlerFunc
+	HealthHandler http.HandlerFunc
 	InfoHandler   http.HandlerFunc
 }
 


### PR DESCRIPTION
Vendoring the faas-provider package version 0.9.0
and renamig the Health to HealthHandler

Signed-off-by: Martin Dekov <mdekov@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Renaming `Health` to `HealthHandler` in `server.go` and re-vendor the faas-provicer package 0.9.0

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Closes https://github.com/openfaas/faas-provider/issues/17

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] I have run the [certifier](https://github.com/openfaas/certifier)

Built image:

Create instance with the operator turned on using helm:
```
helm upgrade openfaas --install openfaas/openfaas     --namespace openfaas      --set functionNamespace=openfaas-fn     --set operator.create=true --setoperator.image=martindekov/operator_image:0.0.1
```
curl `healthz` endpoint:
```
$ curl http://192.168.99.100:31112/healthz -i
HTTP/1.1 200 OK
Content-Length: 2
Content-Type: text/plain; charset=utf-8
Date: Sat, 04 May 2019 10:24:01 GMT
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Impact to existing users
<!-- What must existing users do to adopt this change? -->
N/A
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
