### PR TITLE
Add logs feature and namespace dummy endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ faas-o6s
 .idea/
 
 openfaas-operator
+/.kube

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /go/src/github.com/openfaas-incubator/openfaas-operator
 
 COPY . .
 
-RUN gofmt -l -d $(find . -type f -name '*.go' -not -path "./vendor/*") && \
+RUN go test ./... && \
+  gofmt -l -d $(find . -type f -name '*.go' -not -path "./vendor/*") && \
   VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///') && \
   GIT_COMMIT=$(git rev-list -1 HEAD) && \
   CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w \

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -193,35 +193,38 @@
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:0250441ac9f681c839722297897952ee6d633f2a37dc254eca9d6d21bd1e877d"
+  digest = "1:cdf3df431e70077f94e14a99305808e3d13e96262b4686154970f448f7248842"
   name = "github.com/openfaas/faas"
   packages = ["gateway/requests"]
   pruneopts = "UT"
-  revision = "0a90125aba339a8133009f215ed6d2d8c19277f8"
-  version = "0.17.4"
+  revision = "365f459b3f3a05ad17ce83f4edd86f4276af354a"
+  version = "0.18.3"
 
 [[projects]]
-  digest = "1:57c7042e9519e1e53f9507890fded28a8efa5ad44961f56d3ac7c152065ff442"
+  digest = "1:31b0bad56cdf91e954a4a6bb7993629ef56b7003b2bb3a0cc75bad632f89f82c"
   name = "github.com/openfaas/faas-netes"
   packages = [
+    "handlers",
     "k8s",
     "types",
   ]
   pruneopts = "UT"
-  revision = "c5a1b7bff20a6cc9e1da23d8484355be6e558e8d"
-  version = "0.9.2"
+  revision = "c0076596d7cbf03e61c2ab4775c6f46ea9254c64"
+  version = "0.9.13"
 
 [[projects]]
-  digest = "1:9dd8ab815d9379ac78c3ed7e57fa3846d2dd4e11dbd70b49a51c14356866dd21"
+  digest = "1:6e5bab2d783adc28115076def0cdc279aee07453be6983be54185fc0bb4f67ea"
   name = "github.com/openfaas/faas-provider"
   packages = [
     ".",
     "auth",
+    "httputil",
+    "logs",
     "types",
   ]
   pruneopts = "UT"
-  revision = "eafd85a3b360d8e0982c3a1db43e6d5fee9b85e2"
-  version = "0.10.2"
+  revision = "7677057e416ba796df41f9f366956a491c5684ff"
+  version = "0.13.2"
 
 [[projects]]
   branch = "master"
@@ -748,9 +751,11 @@
   input-imports = [
     "github.com/google/go-cmp/cmp",
     "github.com/gorilla/mux",
+    "github.com/openfaas/faas-netes/handlers",
     "github.com/openfaas/faas-netes/k8s",
     "github.com/openfaas/faas-netes/types",
     "github.com/openfaas/faas-provider",
+    "github.com/openfaas/faas-provider/logs",
     "github.com/openfaas/faas-provider/types",
     "github.com/openfaas/faas/gateway/requests",
     "github.com/prometheus/client_golang/prometheus/promhttp",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -15,11 +15,11 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
     go-tests = false
 
 [[override]]
-  name = "k8s.io/apimachinery"
+  name = "k8s.io/code-generator"
   branch = "release-1.12"
 
 [[override]]
-  name = "k8s.io/code-generator"
+  name = "k8s.io/apimachinery"
   branch = "release-1.12"
 
 [[override]]
@@ -31,18 +31,6 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
   version = "v0.1.0"
 
 [[constraint]]
-  name = "github.com/openfaas/faas-provider"
-  version = "0.10.2"
-
-[[constraint]]
-  name = "github.com/openfaas/faas"
-  version = "0.17.3"
-
-[[constraint]]
-  name = "github.com/openfaas/faas-netes"
-  version = "0.9.2"
-
-[[constraint]]
   name = "github.com/prometheus/client_golang"
   version = "v0.9.2"
 
@@ -50,4 +38,14 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
   name = "github.com/google/go-cmp"
   version = "v0.2.0"
 
+[[constraint]]
+  name = "github.com/openfaas/faas-provider"
+  version = "0.13.2"
 
+[[constraint]]
+  name = "github.com/openfaas/faas"
+  version = "0.18.3"
+
+[[constraint]]
+  name = "github.com/openfaas/faas-netes"
+  version = "0.9.13"

--- a/main.go
+++ b/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"flag"
-	"github.com/openfaas/faas-netes/k8s"
 	"os"
 	"time"
+
+	"github.com/openfaas/faas-netes/k8s"
+	providertypes "github.com/openfaas/faas-provider/types"
 
 	clientset "github.com/openfaas-incubator/openfaas-operator/pkg/client/clientset/versioned"
 	informers "github.com/openfaas-incubator/openfaas-operator/pkg/client/informers/externalversions"
@@ -66,8 +68,12 @@ func main() {
 	}
 
 	readConfig := types.ReadConfig{}
-	osEnv := types.OsEnv{}
-	config := readConfig.Read(osEnv)
+	osEnv := providertypes.OsEnv{}
+	config, err := readConfig.Read(osEnv)
+
+	if err != nil {
+		panic(err)
+	}
 
 	deployConfig := k8s.DeploymentConfig{
 		RuntimeHTTPPort: 8080,

--- a/pkg/server/namespace.go
+++ b/pkg/server/namespace.go
@@ -1,0 +1,18 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func makeListNamespaceHandler(defaultNamespace string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		defer r.Body.Close()
+
+		res, _ := json.Marshal([]string{defaultNamespace})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(res)
+	}
+}

--- a/pkg/server/secret.go
+++ b/pkg/server/secret.go
@@ -7,7 +7,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/openfaas/faas/gateway/requests"
+	faastypes "github.com/openfaas/faas-provider/types"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -108,8 +109,8 @@ func makeSecretHandler(namespace string, kube kubernetes.Interface) http.Handler
 	}
 }
 
-func getSecrets(namespace string, kube kubernetes.Interface) ([]requests.Secret, error) {
-	secrets := []requests.Secret{}
+func getSecrets(namespace string, kube kubernetes.Interface) ([]faastypes.Secret, error) {
+	secrets := []faastypes.Secret{}
 	selector := fmt.Sprintf("%s=%s", secretLabel, secretLabelValue)
 
 	res, err := kube.CoreV1().Secrets(namespace).List(metav1.ListOptions{LabelSelector: selector})
@@ -119,7 +120,7 @@ func getSecrets(namespace string, kube kubernetes.Interface) ([]requests.Secret,
 	}
 
 	for _, item := range res.Items {
-		secret := requests.Secret{
+		secret := faastypes.Secret{
 			Name: item.Name,
 		}
 		secrets = append(secrets, secret)
@@ -157,7 +158,7 @@ func deleteSecret(namespace string, kube kubernetes.Interface, secret *corev1.Se
 
 func parseSecret(namespace string, r io.Reader) (*corev1.Secret, error) {
 	body, _ := ioutil.ReadAll(r)
-	req := requests.Secret{}
+	req := faastypes.Secret{}
 	if err := json.Unmarshal(body, &req); err != nil {
 		return nil, err
 	}

--- a/pkg/server/secret_test.go
+++ b/pkg/server/secret_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openfaas/faas/gateway/requests"
+	faastypes "github.com/openfaas/faas-provider/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 )
@@ -100,7 +100,7 @@ func Test_makeSecretHandler(t *testing.T) {
 
 		decoder := json.NewDecoder(resp.Body)
 
-		secretList := []requests.Secret{}
+		secretList := []faastypes.Secret{}
 		err := decoder.Decode(&secretList)
 		if err != nil {
 			t.Error(err)

--- a/vendor/github.com/openfaas/faas-netes/handlers/delete.go
+++ b/vendor/github.com/openfaas/faas-netes/handlers/delete.go
@@ -1,0 +1,126 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/openfaas/faas/gateway/requests"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// MakeDeleteHandler delete a function
+func MakeDeleteHandler(defaultNamespace string, clientset *kubernetes.Clientset) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		q := r.URL.Query()
+		namespace := q.Get("namespace")
+
+		lookupNamespace := defaultNamespace
+
+		if len(namespace) > 0 {
+			lookupNamespace = namespace
+		}
+
+		if lookupNamespace == "kube-system" {
+			http.Error(w, "unable to list within the kube-system namespace", http.StatusUnauthorized)
+			return
+		}
+
+		body, _ := ioutil.ReadAll(r.Body)
+
+		request := requests.DeleteFunctionRequest{}
+		err := json.Unmarshal(body, &request)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if len(request.FunctionName) == 0 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		getOpts := metav1.GetOptions{}
+
+		// This makes sure we don't delete non-labelled deployments
+		deployment, findDeployErr := clientset.AppsV1().
+			Deployments(lookupNamespace).
+			Get(request.FunctionName, getOpts)
+
+		if findDeployErr != nil {
+			if errors.IsNotFound(findDeployErr) {
+				w.WriteHeader(http.StatusNotFound)
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+
+			w.Write([]byte(findDeployErr.Error()))
+			return
+		}
+
+		if isFunction(deployment) {
+			err := deleteFunction(lookupNamespace, clientset, request, w)
+			if err != nil {
+				return
+			}
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+
+			w.Write([]byte("Not a function: " + request.FunctionName))
+			return
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+}
+
+func isFunction(deployment *appsv1.Deployment) bool {
+	if deployment != nil {
+		if _, found := deployment.Labels["faas_function"]; found {
+			return true
+		}
+	}
+	return false
+}
+
+func deleteFunction(functionNamespace string, clientset *kubernetes.Clientset, request requests.DeleteFunctionRequest, w http.ResponseWriter) error {
+	foregroundPolicy := metav1.DeletePropagationForeground
+	opts := &metav1.DeleteOptions{PropagationPolicy: &foregroundPolicy}
+
+	if deployErr := clientset.Apps().Deployments(functionNamespace).
+		Delete(request.FunctionName, opts); deployErr != nil {
+
+		if errors.IsNotFound(deployErr) {
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		w.Write([]byte(deployErr.Error()))
+		return fmt.Errorf("error deleting function's deployment")
+	}
+
+	if svcErr := clientset.CoreV1().
+		Services(functionNamespace).
+		Delete(request.FunctionName, opts); svcErr != nil {
+
+		if errors.IsNotFound(svcErr) {
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+
+		w.Write([]byte(svcErr.Error()))
+		return fmt.Errorf("error deleting function's service")
+	}
+	return nil
+}

--- a/vendor/github.com/openfaas/faas-netes/handlers/deploy.go
+++ b/vendor/github.com/openfaas/faas-netes/handlers/deploy.go
@@ -1,0 +1,373 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/openfaas/faas-netes/k8s"
+
+	types "github.com/openfaas/faas-provider/types"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// initialReplicasCount how many replicas to start of creating for a function
+const initialReplicasCount = 1
+
+// MakeDeployHandler creates a handler to create new functions in the cluster
+func MakeDeployHandler(functionNamespace string, factory k8s.FunctionFactory) http.HandlerFunc {
+	secrets := k8s.NewSecretsClient(factory.Client)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		if r.Body != nil {
+			defer r.Body.Close()
+		}
+
+		body, _ := ioutil.ReadAll(r.Body)
+
+		request := types.FunctionDeployment{}
+		err := json.Unmarshal(body, &request)
+		if err != nil {
+			wrappedErr := fmt.Errorf("failed to unmarshal request: %s", err.Error())
+			http.Error(w, wrappedErr.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if err := ValidateDeployRequest(&request); err != nil {
+			wrappedErr := fmt.Errorf("validation failed: %s", err.Error())
+			http.Error(w, wrappedErr.Error(), http.StatusBadRequest)
+			return
+		}
+
+		namespace := functionNamespace
+		if len(request.Namespace) > 0 {
+			namespace = request.Namespace
+		}
+
+		existingSecrets, err := secrets.GetSecrets(namespace, request.Secrets)
+		if err != nil {
+			wrappedErr := fmt.Errorf("unable to fetch secrets: %s", err.Error())
+			http.Error(w, wrappedErr.Error(), http.StatusBadRequest)
+			return
+		}
+
+		deploymentSpec, specErr := makeDeploymentSpec(request, existingSecrets, factory)
+
+		if specErr != nil {
+			wrappedErr := fmt.Errorf("failed create Deployment spec: %s", specErr.Error())
+			log.Println(wrappedErr)
+			http.Error(w, wrappedErr.Error(), http.StatusBadRequest)
+			return
+		}
+
+		deploy := factory.Client.AppsV1().Deployments(namespace)
+
+		_, err = deploy.Create(deploymentSpec)
+		if err != nil {
+			wrappedErr := fmt.Errorf("unable create Deployment: %s", err.Error())
+			log.Println(wrappedErr)
+			http.Error(w, wrappedErr.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		log.Printf("Deployment created: %s.%s\n", request.Service, namespace)
+
+		service := factory.Client.Core().Services(namespace)
+		serviceSpec := makeServiceSpec(request, factory)
+		_, err = service.Create(serviceSpec)
+
+		if err != nil {
+			wrappedErr := fmt.Errorf("failed create Service: %s", err.Error())
+			log.Println(wrappedErr)
+			http.Error(w, wrappedErr.Error(), http.StatusBadRequest)
+			return
+		}
+
+		log.Printf("Service created: %s.%s\n", request.Service, namespace)
+
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+}
+
+func makeDeploymentSpec(request types.FunctionDeployment, existingSecrets map[string]*apiv1.Secret, factory k8s.FunctionFactory) (*appsv1.Deployment, error) {
+	envVars := buildEnvVars(&request)
+
+	initialReplicas := int32p(initialReplicasCount)
+	labels := map[string]string{
+		"faas_function": request.Service,
+	}
+
+	if request.Labels != nil {
+		if min := getMinReplicaCount(*request.Labels); min != nil {
+			initialReplicas = min
+		}
+		for k, v := range *request.Labels {
+			labels[k] = v
+		}
+	}
+
+	nodeSelector := createSelector(request.Constraints)
+
+	resources, resourceErr := createResources(request)
+
+	if resourceErr != nil {
+		return nil, resourceErr
+	}
+
+	var imagePullPolicy apiv1.PullPolicy
+	switch factory.Config.ImagePullPolicy {
+	case "Never":
+		imagePullPolicy = apiv1.PullNever
+	case "IfNotPresent":
+		imagePullPolicy = apiv1.PullIfNotPresent
+	default:
+		imagePullPolicy = apiv1.PullAlways
+	}
+
+	annotations := buildAnnotations(request)
+
+	var serviceAccount string
+
+	if request.Annotations != nil {
+		annotations := *request.Annotations
+		if val, ok := annotations["com.openfaas.serviceaccount"]; ok && len(val) > 0 {
+			serviceAccount = val
+		}
+	}
+
+	probes, err := factory.MakeProbes(request)
+	if err != nil {
+		return nil, err
+	}
+
+	deploymentSpec := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        request.Service,
+			Annotations: annotations,
+			Labels: map[string]string{
+				"faas_function": request.Service,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"faas_function": request.Service,
+				},
+			},
+			Replicas: initialReplicas,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: int32(0),
+					},
+					MaxSurge: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: int32(1),
+					},
+				},
+			},
+			RevisionHistoryLimit: int32p(10),
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        request.Service,
+					Labels:      labels,
+					Annotations: annotations,
+				},
+				Spec: apiv1.PodSpec{
+					NodeSelector: nodeSelector,
+					Containers: []apiv1.Container{
+						{
+							Name:  request.Service,
+							Image: request.Image,
+							Ports: []apiv1.ContainerPort{
+								{ContainerPort: factory.Config.RuntimeHTTPPort, Protocol: corev1.ProtocolTCP},
+							},
+							Env:             envVars,
+							Resources:       *resources,
+							ImagePullPolicy: imagePullPolicy,
+							LivenessProbe:   probes.Liveness,
+							ReadinessProbe:  probes.Readiness,
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem: &request.ReadOnlyRootFilesystem,
+							},
+						},
+					},
+					ServiceAccountName: serviceAccount,
+					RestartPolicy:      corev1.RestartPolicyAlways,
+					DNSPolicy:          corev1.DNSClusterFirst,
+				},
+			},
+		},
+	}
+
+	factory.ConfigureReadOnlyRootFilesystem(request, deploymentSpec)
+	factory.ConfigureContainerUserID(deploymentSpec)
+
+	if err := factory.ConfigureSecrets(request, deploymentSpec, existingSecrets); err != nil {
+		return nil, err
+	}
+
+	return deploymentSpec, nil
+}
+
+func makeServiceSpec(request types.FunctionDeployment, factory k8s.FunctionFactory) *corev1.Service {
+
+	serviceSpec := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        request.Service,
+			Annotations: buildAnnotations(request),
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{
+				"faas_function": request.Service,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "http",
+					Protocol: corev1.ProtocolTCP,
+					Port:     factory.Config.RuntimeHTTPPort,
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: factory.Config.RuntimeHTTPPort,
+					},
+				},
+			},
+		},
+	}
+
+	return serviceSpec
+}
+
+func buildAnnotations(request types.FunctionDeployment) map[string]string {
+	var annotations map[string]string
+	if request.Annotations != nil {
+		annotations = *request.Annotations
+	} else {
+		annotations = map[string]string{}
+	}
+
+	annotations["prometheus.io.scrape"] = "false"
+	return annotations
+}
+
+func buildEnvVars(request *types.FunctionDeployment) []corev1.EnvVar {
+	envVars := []corev1.EnvVar{}
+
+	if len(request.EnvProcess) > 0 {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  k8s.EnvProcessName,
+			Value: request.EnvProcess,
+		})
+	}
+
+	for k, v := range request.EnvVars {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  k,
+			Value: v,
+		})
+	}
+
+	sort.SliceStable(envVars, func(i, j int) bool {
+		return strings.Compare(envVars[i].Name, envVars[j].Name) == -1
+	})
+
+	return envVars
+}
+
+func int32p(i int32) *int32 {
+	return &i
+}
+
+func createSelector(constraints []string) map[string]string {
+	selector := make(map[string]string)
+
+	if len(constraints) > 0 {
+		for _, constraint := range constraints {
+			parts := strings.Split(constraint, "=")
+
+			if len(parts) == 2 {
+				selector[parts[0]] = parts[1]
+			}
+		}
+	}
+
+	return selector
+}
+
+func createResources(request types.FunctionDeployment) (*apiv1.ResourceRequirements, error) {
+	resources := &apiv1.ResourceRequirements{
+		Limits:   apiv1.ResourceList{},
+		Requests: apiv1.ResourceList{},
+	}
+
+	// Set Memory limits
+	if request.Limits != nil && len(request.Limits.Memory) > 0 {
+		qty, err := resource.ParseQuantity(request.Limits.Memory)
+		if err != nil {
+			return resources, err
+		}
+		resources.Limits[apiv1.ResourceMemory] = qty
+	}
+
+	if request.Requests != nil && len(request.Requests.Memory) > 0 {
+		qty, err := resource.ParseQuantity(request.Requests.Memory)
+		if err != nil {
+			return resources, err
+		}
+		resources.Requests[apiv1.ResourceMemory] = qty
+	}
+
+	// Set CPU limits
+	if request.Limits != nil && len(request.Limits.CPU) > 0 {
+		qty, err := resource.ParseQuantity(request.Limits.CPU)
+		if err != nil {
+			return resources, err
+		}
+		resources.Limits[apiv1.ResourceCPU] = qty
+	}
+
+	if request.Requests != nil && len(request.Requests.CPU) > 0 {
+		qty, err := resource.ParseQuantity(request.Requests.CPU)
+		if err != nil {
+			return resources, err
+		}
+		resources.Requests[apiv1.ResourceCPU] = qty
+	}
+
+	return resources, nil
+}
+
+func getMinReplicaCount(labels map[string]string) *int32 {
+	if value, exists := labels["com.openfaas.scale.min"]; exists {
+		minReplicas, err := strconv.Atoi(value)
+		if err == nil && minReplicas > 0 {
+			return int32p(int32(minReplicas))
+		}
+
+		log.Println(err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/openfaas/faas-netes/handlers/errors.go
+++ b/vendor/github.com/openfaas/faas-netes/handlers/errors.go
@@ -1,0 +1,34 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"net/http"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ProcessErrorReasons maps k8serrors.ReasonForError to http status codes
+func ProcessErrorReasons(err error) (int, metav1.StatusReason) {
+	reason := k8serrors.ReasonForError(err)
+	switch reason {
+	case metav1.StatusReasonGone, metav1.StatusReasonNotFound:
+		return http.StatusNotFound, reason
+	case metav1.StatusReasonAlreadyExists:
+		return http.StatusConflict, reason
+	case metav1.StatusReasonConflict:
+		return http.StatusConflict, reason
+	case metav1.StatusReasonInvalid:
+		return http.StatusUnprocessableEntity, reason
+	case metav1.StatusReasonBadRequest:
+		return http.StatusBadRequest, reason
+	case metav1.StatusReasonForbidden:
+		return http.StatusForbidden, reason
+	case metav1.StatusReasonTimeout:
+		return http.StatusRequestTimeout, reason
+	default:
+		return http.StatusInternalServerError, metav1.StatusReasonInternalError
+	}
+}

--- a/vendor/github.com/openfaas/faas-netes/handlers/health.go
+++ b/vendor/github.com/openfaas/faas-netes/handlers/health.go
@@ -1,0 +1,15 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import "net/http"
+
+// MakeHealthHandler returns 200/OK when healthy
+func MakeHealthHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		w.WriteHeader(http.StatusOK)
+	}
+}

--- a/vendor/github.com/openfaas/faas-netes/handlers/info.go
+++ b/vendor/github.com/openfaas/faas-netes/handlers/info.go
@@ -1,0 +1,46 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/openfaas/faas-provider/types"
+)
+
+const (
+	//OrchestrationIdentifier identifier string for provider orchestration
+	OrchestrationIdentifier = "kubernetes"
+	//ProviderName name of the provider
+	ProviderName = "faas-netes"
+)
+
+//MakeInfoHandler creates handler for /system/info endpoint
+func MakeInfoHandler(version, sha string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			defer r.Body.Close()
+		}
+
+		infoRequest := types.InfoRequest{
+			Orchestration: OrchestrationIdentifier,
+			Provider:      ProviderName,
+			Version: types.ProviderVersion{
+				Release: version,
+				SHA:     sha,
+			},
+		}
+
+		jsonOut, marshalErr := json.Marshal(infoRequest)
+		if marshalErr != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(jsonOut)
+	}
+}

--- a/vendor/github.com/openfaas/faas-netes/handlers/namespaces.go
+++ b/vendor/github.com/openfaas/faas-netes/handlers/namespaces.go
@@ -1,0 +1,110 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// MakeNamespacesLister builds a list of namespaces with an "openfaas" tag, or the default name
+func MakeNamespacesLister(defaultNamespace string, clientset kubernetes.Interface) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Query namespaces")
+
+		res := list(defaultNamespace, clientset)
+
+		out, _ := json.Marshal(res)
+		w.Header().Set("Content-Type", "application/json")
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Write(out)
+	}
+}
+
+// NamespaceResolver is a method that determines the requested namespace corresponding to an
+// HTTP request. It then validates that OpenFaaS is permitted to operate in that the namespace.
+type NamespaceResolver func(r *http.Request) (namespace string, err error)
+
+// NewNamespaceResolver returns a generic namespace resolver that will inspect both the GET query
+// parameters and the request body. It looks for the query param or json key "namespace".
+func NewNamespaceResolver(defaultNamespace string, kube kubernetes.Interface) NamespaceResolver {
+	return func(r *http.Request) (string, error) {
+		req := struct{ Namespace string }{Namespace: defaultNamespace}
+
+		switch r.Method {
+		case http.MethodGet:
+			q := r.URL.Query()
+			namespace := q.Get("namespace")
+
+			if len(namespace) > 0 {
+				req.Namespace = namespace
+			}
+
+		case http.MethodPost, http.MethodPut, http.MethodDelete:
+			body, _ := ioutil.ReadAll(r.Body)
+			err := json.Unmarshal(body, &req)
+			if err != nil {
+				log.Printf("error while getting namespace: %s\n", err)
+				return "", fmt.Errorf("unable to unmarshal json request")
+			}
+
+			// Reconstruct Body
+			r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		}
+
+		allowedNamespaces := list(defaultNamespace, kube)
+		ok := findNamespace(req.Namespace, allowedNamespaces)
+		if !ok {
+			return req.Namespace, fmt.Errorf("unable to manage secrets within the %s namespace", req.Namespace)
+		}
+
+		return req.Namespace, nil
+	}
+}
+
+func list(defaultNamespace string, clientset kubernetes.Interface) []string {
+	listOptions := metav1.ListOptions{}
+	namespaces, err := clientset.CoreV1().Namespaces().List(listOptions)
+
+	set := []string{}
+
+	// Assume that an error means that a Role, instead of ClusterRole is being used
+	// the Role will not be able to list namespaces, so all functions are in the
+	// defaultNamespace
+	if err != nil {
+		log.Printf("Error listing namespaces: %s", err.Error())
+		set = append(set, defaultNamespace)
+		return set
+	}
+
+	for _, n := range namespaces.Items {
+		if _, ok := n.Annotations["openfaas"]; ok {
+			set = append(set, n.Name)
+		}
+	}
+
+	if !findNamespace(defaultNamespace, set) {
+		set = append(set, defaultNamespace)
+	}
+
+	return set
+}
+
+func findNamespace(target string, items []string) bool {
+	for _, n := range items {
+		if n == target {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/openfaas/faas-netes/handlers/proxy.go
+++ b/vendor/github.com/openfaas/faas-netes/handlers/proxy.go
@@ -1,0 +1,97 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"fmt"
+	"math/rand"
+	"net/url"
+	"strings"
+	"sync"
+
+	corelister "k8s.io/client-go/listers/core/v1"
+)
+
+// watchdogPort for the OpenFaaS function watchdog
+const watchdogPort = 8080
+
+func NewFunctionLookup(ns string, lister corelister.EndpointsLister) *FunctionLookup {
+	return &FunctionLookup{
+		DefaultNamespace: ns,
+		EndpointLister:   lister,
+		Listers:          map[string]corelister.EndpointsNamespaceLister{},
+		lock:             sync.RWMutex{},
+	}
+}
+
+type FunctionLookup struct {
+	DefaultNamespace string
+	EndpointLister   corelister.EndpointsLister
+	Listers          map[string]corelister.EndpointsNamespaceLister
+
+	lock sync.RWMutex
+}
+
+func (f *FunctionLookup) GetLister(ns string) corelister.EndpointsNamespaceLister {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return f.Listers[ns]
+}
+
+func (f *FunctionLookup) SetLister(ns string, lister corelister.EndpointsNamespaceLister) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.Listers[ns] = lister
+}
+
+func getNamespace(name, defaultNamespace string) string {
+	namespace := defaultNamespace
+	if strings.Contains(name, ".") {
+		namespace = name[strings.LastIndexAny(name, ".")+1:]
+	}
+	return namespace
+}
+
+func (l *FunctionLookup) Resolve(name string) (url.URL, error) {
+
+	namespace := getNamespace(name, l.DefaultNamespace)
+	if err := l.verifyNamespace(namespace); err != nil {
+		return url.URL{}, err
+	}
+
+	nsEndpointLister := l.GetLister(namespace)
+
+	if nsEndpointLister == nil {
+		l.SetLister(namespace, l.EndpointLister.Endpoints(namespace))
+
+		nsEndpointLister = l.GetLister(namespace)
+	}
+
+	svc, err := nsEndpointLister.Get(name)
+	if err != nil {
+		return url.URL{}, fmt.Errorf("error listing %s.%s %s", name, namespace, err.Error())
+	}
+
+	all := len(svc.Subsets[0].Addresses)
+	target := rand.Intn(all)
+
+	serviceIP := svc.Subsets[0].Addresses[target].IP
+
+	urlStr := fmt.Sprintf("http://%s:%d", serviceIP, watchdogPort)
+
+	urlRes, err := url.Parse(urlStr)
+	if err != nil {
+		return url.URL{}, err
+	}
+
+	return *urlRes, nil
+}
+
+func (l *FunctionLookup) verifyNamespace(name string) error {
+	if name != "kube-system" {
+		return nil
+	}
+	// ToDo use global namepace parse and validation
+	return fmt.Errorf("namespace not allowed")
+}

--- a/vendor/github.com/openfaas/faas-netes/handlers/reader.go
+++ b/vendor/github.com/openfaas/faas-netes/handlers/reader.go
@@ -1,0 +1,98 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	types "github.com/openfaas/faas-provider/types"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openfaas/faas-netes/k8s"
+)
+
+// MakeFunctionReader handler for reading functions deployed in the cluster as deployments.
+func MakeFunctionReader(defaultNamespace string, clientset *kubernetes.Clientset) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		q := r.URL.Query()
+		namespace := q.Get("namespace")
+
+		lookupNamespace := defaultNamespace
+
+		if len(namespace) > 0 {
+			lookupNamespace = namespace
+		}
+
+		if lookupNamespace == "kube-system" {
+			http.Error(w, "unable to list within the kube-system namespace", http.StatusUnauthorized)
+			return
+		}
+
+		functions, err := getServiceList(lookupNamespace, clientset)
+		if err != nil {
+			log.Println(err)
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(err.Error()))
+			return
+		}
+
+		functionBytes, _ := json.Marshal(functions)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(functionBytes)
+	}
+}
+
+func getServiceList(functionNamespace string, clientset *kubernetes.Clientset) ([]types.FunctionStatus, error) {
+	functions := []types.FunctionStatus{}
+
+	listOpts := metav1.ListOptions{
+		LabelSelector: "faas_function",
+	}
+
+	res, err := clientset.AppsV1().Deployments(functionNamespace).List(listOpts)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range res.Items {
+		function := k8s.AsFunctionStatus(item)
+		if function != nil {
+			functions = append(functions, *function)
+		}
+	}
+	return functions, nil
+}
+
+// getService returns a function/service or nil if not found
+func getService(functionNamespace string, functionName string, clientset *kubernetes.Clientset) (*types.FunctionStatus, error) {
+
+	getOpts := metav1.GetOptions{}
+
+	item, err := clientset.AppsV1().Deployments(functionNamespace).Get(functionName, getOpts)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	if item != nil {
+		function := k8s.AsFunctionStatus(*item)
+		if function != nil {
+			return function, nil
+		}
+	}
+
+	return nil, fmt.Errorf("function: %s not found", functionName)
+}

--- a/vendor/github.com/openfaas/faas-netes/handlers/replicas.go
+++ b/vendor/github.com/openfaas/faas-netes/handlers/replicas.go
@@ -1,0 +1,125 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/openfaas/faas-netes/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// MakeReplicaUpdater updates desired count of replicas
+func MakeReplicaUpdater(defaultNamespace string, clientset *kubernetes.Clientset) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Update replicas")
+
+		vars := mux.Vars(r)
+
+		functionName := vars["name"]
+		q := r.URL.Query()
+		namespace := q.Get("namespace")
+
+		lookupNamespace := defaultNamespace
+
+		if len(namespace) > 0 {
+			lookupNamespace = namespace
+		}
+
+		req := types.ScaleServiceRequest{}
+
+		if r.Body != nil {
+			defer r.Body.Close()
+			bytesIn, _ := ioutil.ReadAll(r.Body)
+			marshalErr := json.Unmarshal(bytesIn, &req)
+			if marshalErr != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				msg := "Cannot parse request. Please pass valid JSON."
+				w.Write([]byte(msg))
+				log.Println(msg, marshalErr)
+				return
+			}
+		}
+
+		if len(req.ServiceNamespace) > 0 {
+			lookupNamespace = req.ServiceNamespace
+		}
+
+		options := metav1.GetOptions{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+			},
+		}
+
+		deployment, err := clientset.Apps().Deployments(lookupNamespace).Get(functionName, options)
+
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("Unable to lookup function deployment " + functionName))
+			log.Println(err)
+			return
+		}
+
+		oldReplicas := *deployment.Spec.Replicas
+		replicas := int32(req.Replicas)
+
+		log.Printf("Set replicas - %s %s, %d/%d\n", functionName, lookupNamespace, replicas, oldReplicas)
+
+		deployment.Spec.Replicas = &replicas
+
+		_, err = clientset.Apps().Deployments(lookupNamespace).Update(deployment)
+
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("Unable to update function deployment " + functionName))
+			log.Println(err)
+			return
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+	}
+}
+
+// MakeReplicaReader reads the amount of replicas for a deployment
+func MakeReplicaReader(defaultNamespace string, clientset *kubernetes.Clientset) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		vars := mux.Vars(r)
+
+		functionName := vars["name"]
+		q := r.URL.Query()
+		namespace := q.Get("namespace")
+
+		lookupNamespace := defaultNamespace
+
+		if len(namespace) > 0 {
+			lookupNamespace = namespace
+		}
+
+		function, err := getService(lookupNamespace, functionName, clientset)
+		if err != nil {
+			log.Printf("Unable to fetch service: %s %s\n", functionName, namespace)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if function == nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		log.Printf("Read replicas - %s %s, %d/%d\n", functionName, lookupNamespace, function.AvailableReplicas, function.Replicas)
+
+		functionBytes, _ := json.Marshal(function)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(functionBytes)
+	}
+}

--- a/vendor/github.com/openfaas/faas-netes/handlers/secrets.go
+++ b/vendor/github.com/openfaas/faas-netes/handlers/secrets.go
@@ -1,0 +1,151 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/openfaas/faas-netes/k8s"
+	types "github.com/openfaas/faas-provider/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// MakeSecretHandler makes a handler for Create/List/Delete/Update of
+//secrets in the Kubernetes API
+func MakeSecretHandler(defaultNamespace string, kube kubernetes.Interface) http.HandlerFunc {
+	handler := secretsHandler{
+		lookupNamespace: NewNamespaceResolver(defaultNamespace, kube),
+		secrets:         k8s.NewSecretsClient(kube),
+	}
+	return handler.ServeHTTP
+}
+
+type secretsHandler struct {
+	secrets         k8s.SecretsClient
+	lookupNamespace NamespaceResolver
+}
+
+func (h secretsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Body != nil {
+		defer r.Body.Close()
+	}
+
+	lookupNamespace, err := h.lookupNamespace(r)
+	if err != nil {
+		switch err.Error() {
+		case "unable to unmarshal Secret request":
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		case "unable to manage secrets within the specified namespace":
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.listSecrets(lookupNamespace, w, r)
+	case http.MethodPost:
+		h.createSecret(lookupNamespace, w, r)
+	case http.MethodPut:
+		h.replaceSecret(lookupNamespace, w, r)
+	case http.MethodDelete:
+		h.deleteSecret(lookupNamespace, w, r)
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+}
+
+func (h secretsHandler) listSecrets(namespace string, w http.ResponseWriter, r *http.Request) {
+	res, err := h.secrets.List(namespace)
+	if err != nil {
+		status, reason := ProcessErrorReasons(err)
+		log.Printf("Secret list error reason: %s, %v\n", reason, err)
+		w.WriteHeader(status)
+		return
+	}
+
+	secrets := make([]types.Secret, len(res))
+	for idx, name := range res {
+		secrets[idx] = types.Secret{
+			Name:      name,
+			Namespace: namespace,
+		}
+	}
+	secretsBytes, err := json.Marshal(secrets)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Printf("Secrets json marshal error: %v\n", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(secretsBytes)
+}
+
+func (h secretsHandler) createSecret(namespace string, w http.ResponseWriter, r *http.Request) {
+	secret := types.Secret{}
+	err := json.NewDecoder(r.Body).Decode(&secret)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		log.Printf("Secret unmarshal error: %v\n", err)
+		return
+	}
+
+	secret.Namespace = namespace
+	err = h.secrets.Create(secret)
+	if err != nil {
+		status, reason := ProcessErrorReasons(err)
+		log.Printf("Secret create error reason: %s, %v\n", reason, err)
+		w.WriteHeader(status)
+		return
+	}
+	log.Printf("Secret %s create\n", secret.Name)
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h secretsHandler) replaceSecret(namespace string, w http.ResponseWriter, r *http.Request) {
+	secret := types.Secret{}
+	err := json.NewDecoder(r.Body).Decode(&secret)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		log.Printf("Secret unmarshal error: %v\n", err)
+		return
+	}
+
+	secret.Namespace = namespace
+	err = h.secrets.Replace(secret)
+	if err != nil {
+		status, reason := ProcessErrorReasons(err)
+		log.Printf("Secret update error reason: %s, %v\n", reason, err)
+		w.WriteHeader(status)
+		return
+	}
+	log.Printf("Secret %s updated", secret.Name)
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h secretsHandler) deleteSecret(namespace string, w http.ResponseWriter, r *http.Request) {
+	secret := types.Secret{}
+	err := json.NewDecoder(r.Body).Decode(&secret)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		log.Printf("Secret unmarshal error: %v\n", err)
+		return
+	}
+
+	err = h.secrets.Delete(namespace, secret.Name)
+	if err != nil {
+		status, reason := ProcessErrorReasons(err)
+		log.Printf("Secret delete error reason: %s, %v\n", reason, err)
+		w.WriteHeader(status)
+		return
+	}
+	log.Printf("Secret %s deleted\n", secret.Name)
+	w.WriteHeader(http.StatusAccepted)
+}

--- a/vendor/github.com/openfaas/faas-netes/handlers/update.go
+++ b/vendor/github.com/openfaas/faas-netes/handlers/update.go
@@ -1,0 +1,202 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/openfaas/faas-netes/k8s"
+
+	types "github.com/openfaas/faas-provider/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// MakeUpdateHandler update specified function
+func MakeUpdateHandler(defaultNamespace string, factory k8s.FunctionFactory) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			defer r.Body.Close()
+		}
+
+		body, _ := ioutil.ReadAll(r.Body)
+
+		request := types.FunctionDeployment{}
+		err := json.Unmarshal(body, &request)
+		if err != nil {
+			wrappedErr := fmt.Errorf("unable to unmarshal request: %s", err.Error())
+			http.Error(w, wrappedErr.Error(), http.StatusBadRequest)
+			return
+		}
+
+		lookupNamespace := defaultNamespace
+		if len(request.Namespace) > 0 {
+			lookupNamespace = request.Namespace
+		}
+
+		if lookupNamespace == "kube-system" {
+			http.Error(w, "unable to list within the kube-system namespace", http.StatusUnauthorized)
+			return
+		}
+
+		annotations := buildAnnotations(request)
+		if err, status := updateDeploymentSpec(lookupNamespace, factory, request, annotations); err != nil {
+			if !k8s.IsNotFound(err) {
+				log.Printf("error updating deployment: %s.%s, error: %s\n", request.Service, lookupNamespace, err)
+
+				return
+			}
+
+			wrappedErr := fmt.Errorf("unable update Deployment: %s.%s, error: %s", request.Service, lookupNamespace, err.Error())
+			http.Error(w, wrappedErr.Error(), status)
+			return
+		}
+
+		if err, status := updateService(lookupNamespace, factory, request, annotations); err != nil {
+			if !k8s.IsNotFound(err) {
+				log.Printf("error updating service: %s.%s, error: %s\n", request.Service, lookupNamespace, err)
+			}
+
+			wrappedErr := fmt.Errorf("unable update Service: %s.%s, error: %s", request.Service, request.Namespace, err.Error())
+			http.Error(w, wrappedErr.Error(), status)
+			return
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+	}
+}
+
+func updateDeploymentSpec(
+	functionNamespace string,
+	factory k8s.FunctionFactory,
+	request types.FunctionDeployment,
+	annotations map[string]string) (err error, httpStatus int) {
+
+	getOpts := metav1.GetOptions{}
+
+	deployment, findDeployErr := factory.Client.AppsV1().
+		Deployments(functionNamespace).
+		Get(request.Service, getOpts)
+
+	if findDeployErr != nil {
+		return findDeployErr, http.StatusNotFound
+	}
+
+	if len(deployment.Spec.Template.Spec.Containers) > 0 {
+		deployment.Spec.Template.Spec.Containers[0].Image = request.Image
+
+		// Disabling update support to prevent unexpected mutations of deployed functions,
+		// since imagePullPolicy is now configurable. This could be reconsidered later depending
+		// on desired behavior, but will need to be updated to take config.
+		//deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = v1.PullAlways
+
+		deployment.Spec.Template.Spec.Containers[0].Env = buildEnvVars(&request)
+
+		factory.ConfigureReadOnlyRootFilesystem(request, deployment)
+		factory.ConfigureContainerUserID(deployment)
+
+		deployment.Spec.Template.Spec.NodeSelector = createSelector(request.Constraints)
+
+		labels := map[string]string{
+			"faas_function": request.Service,
+			"uid":           fmt.Sprintf("%d", time.Now().Nanosecond()),
+		}
+
+		if request.Labels != nil {
+			if min := getMinReplicaCount(*request.Labels); min != nil {
+				deployment.Spec.Replicas = min
+			}
+
+			for k, v := range *request.Labels {
+				labels[k] = v
+			}
+		}
+
+		// deployment.Labels = labels
+		deployment.Spec.Template.ObjectMeta.Labels = labels
+
+		deployment.Annotations = annotations
+		deployment.Spec.Template.Annotations = annotations
+		deployment.Spec.Template.ObjectMeta.Annotations = annotations
+
+		resources, resourceErr := createResources(request)
+		if resourceErr != nil {
+			return resourceErr, http.StatusBadRequest
+		}
+
+		deployment.Spec.Template.Spec.Containers[0].Resources = *resources
+
+		var serviceAccount string
+
+		if request.Annotations != nil {
+			annotations := *request.Annotations
+			if val, ok := annotations["com.openfaas.serviceaccount"]; ok && len(val) > 0 {
+				serviceAccount = val
+			}
+		}
+
+		deployment.Spec.Template.Spec.ServiceAccountName = serviceAccount
+
+		secrets := k8s.NewSecretsClient(factory.Client)
+		existingSecrets, err := secrets.GetSecrets(functionNamespace, request.Secrets)
+		if err != nil {
+			return err, http.StatusBadRequest
+		}
+
+		err = factory.ConfigureSecrets(request, deployment, existingSecrets)
+		if err != nil {
+			log.Println(err)
+			return err, http.StatusBadRequest
+		}
+
+		probes, err := factory.MakeProbes(request)
+		if err != nil {
+			return err, http.StatusBadRequest
+		}
+
+		deployment.Spec.Template.Spec.Containers[0].LivenessProbe = probes.Liveness
+		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe = probes.Readiness
+	}
+
+	if _, updateErr := factory.Client.AppsV1().
+		Deployments(functionNamespace).
+		Update(deployment); updateErr != nil {
+
+		return updateErr, http.StatusInternalServerError
+	}
+
+	return nil, http.StatusAccepted
+}
+
+func updateService(
+	functionNamespace string,
+	factory k8s.FunctionFactory,
+	request types.FunctionDeployment,
+	annotations map[string]string) (err error, httpStatus int) {
+
+	getOpts := metav1.GetOptions{}
+
+	service, findServiceErr := factory.Client.CoreV1().
+		Services(functionNamespace).
+		Get(request.Service, getOpts)
+
+	if findServiceErr != nil {
+		return findServiceErr, http.StatusNotFound
+	}
+
+	service.Annotations = annotations
+
+	if _, updateErr := factory.Client.CoreV1().
+		Services(functionNamespace).
+		Update(service); updateErr != nil {
+
+		return updateErr, http.StatusInternalServerError
+	}
+
+	return nil, http.StatusAccepted
+}

--- a/vendor/github.com/openfaas/faas-netes/handlers/validate.go
+++ b/vendor/github.com/openfaas/faas-netes/handlers/validate.go
@@ -1,0 +1,25 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"fmt"
+	"regexp"
+
+	types "github.com/openfaas/faas-provider/types"
+)
+
+// Regex for RFC-1123 validation:
+// 	k8s.io/kubernetes/pkg/util/validation/validation.go
+var validDNS = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+// ValidateDeployRequest validates that the service name is valid for Kubernetes
+func ValidateDeployRequest(request *types.FunctionDeployment) error {
+	matched := validDNS.MatchString(request.Service)
+	if matched {
+		return nil
+	}
+
+	return fmt.Errorf("(%s) must be a valid DNS entry for service name", request.Service)
+}

--- a/vendor/github.com/openfaas/faas-netes/k8s/errors.go
+++ b/vendor/github.com/openfaas/faas-netes/k8s/errors.go
@@ -1,0 +1,14 @@
+// Copyright 2019 OpenFaaS Authors
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package k8s
+
+import (
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// isNotFound tests if the error is a kubernetes API error that indicates that the object
+// was not found or does not exist
+func IsNotFound(err error) bool {
+	return k8serrors.IsNotFound(err) || k8serrors.IsGone(err)
+}

--- a/vendor/github.com/openfaas/faas-netes/k8s/function_status.go
+++ b/vendor/github.com/openfaas/faas-netes/k8s/function_status.go
@@ -1,0 +1,43 @@
+// Copyright 2019 OpenFaaS Authors
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package k8s
+
+import (
+	types "github.com/openfaas/faas-provider/types"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// EnvProcessName is the name of the env variable containing the function process
+const EnvProcessName = "fprocess"
+
+// AsFunctionStatus reads a Deployment object into an OpenFaaS FunctionStatus, parsing the
+// Deployment and Container spec into a simplified summary of the Function
+func AsFunctionStatus(item appsv1.Deployment) *types.FunctionStatus {
+	var replicas uint64
+	if item.Spec.Replicas != nil {
+		replicas = uint64(*item.Spec.Replicas)
+	}
+
+	functionContainer := item.Spec.Template.Spec.Containers[0]
+
+	labels := item.Spec.Template.Labels
+	function := types.FunctionStatus{
+		Name:              item.Name,
+		Replicas:          replicas,
+		Image:             functionContainer.Image,
+		AvailableReplicas: uint64(item.Status.AvailableReplicas),
+		InvocationCount:   0,
+		Labels:            &labels,
+		Annotations:       &item.Spec.Template.Annotations,
+		Namespace:         item.Namespace,
+	}
+
+	for _, v := range functionContainer.Env {
+		if EnvProcessName == v.Name {
+			function.EnvProcess = v.Value
+		}
+	}
+
+	return &function
+}

--- a/vendor/github.com/openfaas/faas-netes/k8s/log.go
+++ b/vendor/github.com/openfaas/faas-netes/k8s/log.go
@@ -1,0 +1,54 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package k8s
+
+import (
+	"context"
+	"log"
+
+	"github.com/openfaas/faas-provider/logs"
+	"k8s.io/client-go/kubernetes"
+)
+
+// LogRequestor implements the Requestor interface for k8s
+type LogRequestor struct {
+	client            kubernetes.Interface
+	functionNamespace string
+}
+
+// NewLogRequestor returns a new logs.Requestor that uses kail to select and follow pod logs
+func NewLogRequestor(client kubernetes.Interface, functionNamespace string) *LogRequestor {
+	return &LogRequestor{
+		client:            client,
+		functionNamespace: functionNamespace,
+	}
+}
+
+// Query implements the actual Swarm logs request logic for the Requestor interface
+// This implementation ignores the r.Limit value because the OF-Provider already handles server side
+// line limits.
+func (l LogRequestor) Query(ctx context.Context, r logs.Request) (<-chan logs.Message, error) {
+	logStream, err := GetLogs(ctx, l.client, r.Name, l.functionNamespace, int64(r.Tail), r.Since, r.Follow)
+	if err != nil {
+		log.Printf("LogRequestor: get logs failed: %s\n", err)
+		return nil, err
+	}
+
+	msgStream := make(chan logs.Message, LogBufferSize)
+	go func() {
+		defer close(msgStream)
+		// here we depend on the fact that logStream will close when the context is cancelled,
+		// this ensures that the go routine will resolve
+		for msg := range logStream {
+			msgStream <- logs.Message{
+				Timestamp: msg.Timestamp,
+				Text:      msg.Text,
+				Name:      msg.FunctionName,
+				Instance:  msg.PodName,
+			}
+		}
+	}()
+
+	return msgStream, nil
+}

--- a/vendor/github.com/openfaas/faas-netes/k8s/logs.go
+++ b/vendor/github.com/openfaas/faas-netes/k8s/logs.go
@@ -94,14 +94,17 @@ func podLogs(ctx context.Context, i v1.PodInterface, pod, container, namespace s
 	defer log.Printf("Logger: stopping log stream for %s\n", pod)
 
 	opts := &corev1.PodLogOptions{
-		Follow:       follow,
-		Timestamps:   true,
-		Container:    container,
-		SinceSeconds: parseSince(since),
+		Follow:     follow,
+		Timestamps: true,
+		Container:  container,
 	}
 
 	if tail > 0 {
 		opts.TailLines = &tail
+	}
+
+	if opts.TailLines == nil || since != nil {
+		opts.SinceSeconds = parseSince(since)
 	}
 
 	stream, err := i.GetLogs(pod, opts).Stream()

--- a/vendor/github.com/openfaas/faas-netes/k8s/secrets.go
+++ b/vendor/github.com/openfaas/faas-netes/k8s/secrets.go
@@ -1,0 +1,260 @@
+// Copyright 2019 OpenFaaS Authors
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package k8s
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	types "github.com/openfaas/faas-provider/types"
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	typedV1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const (
+	secretsMountPath = "/var/openfaas/secrets"
+	secretLabel      = "app.kubernetes.io/managed-by"
+	secretLabelValue = "openfaas"
+)
+
+// SecretsClient exposes the standardized CRUD behaviors for Kubernetes secrets.  These methods
+// will ensure that the secrets are structured and labelled correctly for use by the OpenFaaS system.
+type SecretsClient interface {
+	// List returns a list of available function secrets.  Only the names are returned
+	// to ensure we do not accidentally read or print the sensitive values during
+	// read operations.
+	List(namespace string) (names []string, err error)
+	// Create adds a new secret, with the appropriate labels and structure to be
+	// used as a function secret.
+	Create(secret types.Secret) error
+	// Replace updates the value of a function secret
+	Replace(secret types.Secret) error
+	// Delete removes a function secret
+	Delete(name string, namespace string) error
+	// GetSecrets queries Kubernetes for a list of secrets by name in the given k8s namespace.
+	// This should only be used if you need access to the actual secret structure/value. Specifically,
+	// inside the FunctionFactory.
+	GetSecrets(namespace string, secretNames []string) (map[string]*apiv1.Secret, error)
+}
+
+// SecretsInterfacer exposes the SecretInterface getter for the k8s client.
+// This is implemented by the CoreV1Interface() interface in the Kubernetes client.
+// The SecretsClient only needs this one interface, but needs to be able to set the
+// namespaces when the interface is instantiated, meaning, we need the Getter and not the
+// SecretInterface itself.
+type SecretInterfacer interface {
+	// Secrets returns a SecretInterface scoped to the specified namespace
+	Secrets(namespace string) typedV1.SecretInterface
+}
+
+type secretClient struct {
+	kube SecretInterfacer
+}
+
+// NewSecretsClient constructs a new SecretsClient using the provided Kubernetes client.
+func NewSecretsClient(kube kubernetes.Interface) SecretsClient {
+	return &secretClient{
+		kube: kube.CoreV1(),
+	}
+}
+
+func (c secretClient) List(namespace string) (names []string, err error) {
+	res, err := c.kube.Secrets(namespace).List(c.selector())
+	if err != nil {
+		log.Printf("failed to list secrets in %s: %v\n", namespace, err)
+		return nil, err
+	}
+
+	names = make([]string, len(res.Items))
+	for idx, item := range res.Items {
+		// this is safe because size of names matches res.Items exactly
+		names[idx] = item.Name
+	}
+	return names, nil
+}
+
+func (c secretClient) Create(secret types.Secret) error {
+	err := c.validateSecret(secret)
+	if err != nil {
+		return err
+	}
+
+	req := &apiv1.Secret{
+		Type: apiv1.SecretTypeOpaque,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secret.Name,
+			Namespace: secret.Namespace,
+			Labels: map[string]string{
+				secretLabel: secretLabelValue,
+			},
+		},
+		StringData: map[string]string{
+			secret.Name: secret.Value,
+		},
+	}
+
+	_, err = c.kube.Secrets(secret.Namespace).Create(req)
+	if err != nil {
+		log.Printf("failed to create secret %s.%s: %v\n", secret.Name, secret.Namespace, err)
+		return err
+	}
+
+	log.Printf("created secret %s.%s\n", secret.Name, secret.Namespace)
+
+	return nil
+}
+
+func (c secretClient) Replace(secret types.Secret) error {
+	err := c.validateSecret(secret)
+	if err != nil {
+		return err
+	}
+
+	kube := c.kube.Secrets(secret.Namespace)
+	found, err := kube.Get(secret.Name, metav1.GetOptions{})
+	if err != nil {
+		log.Printf("can not retrieve secret for update %s.%s: %v\n", secret.Name, secret.Namespace, err)
+		return err
+	}
+
+	found.StringData = map[string]string{
+		secret.Name: secret.Value,
+	}
+	_, err = kube.Update(found)
+	if err != nil {
+		log.Printf("can not update secret %s.%s: %v\n", secret.Name, secret.Namespace, err)
+		return err
+	}
+
+	return nil
+}
+
+func (c secretClient) Delete(namespace string, name string) error {
+	err := c.kube.Secrets(namespace).Delete(name, &metav1.DeleteOptions{})
+	if err != nil {
+		log.Printf("can not delete %s.%s: %v\n", name, namespace, err)
+	}
+	return err
+}
+
+func (c secretClient) GetSecrets(namespace string, secretNames []string) (map[string]*apiv1.Secret, error) {
+	kube := c.kube.Secrets(namespace)
+	opts := metav1.GetOptions{}
+
+	secrets := map[string]*apiv1.Secret{}
+	for _, secretName := range secretNames {
+		secret, err := kube.Get(secretName, opts)
+		if err != nil {
+			return nil, err
+		}
+		secrets[secretName] = secret
+	}
+
+	return secrets, nil
+}
+
+func (c secretClient) selector() metav1.ListOptions {
+	return metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", secretLabel, secretLabelValue),
+	}
+}
+
+func (c secretClient) validateSecret(secret types.Secret) error {
+	if strings.TrimSpace(secret.Namespace) == "" {
+		return errors.New("namespace may not be empty")
+	}
+
+	if strings.TrimSpace(secret.Name) == "" {
+		return errors.New("name may not be empty")
+	}
+
+	return nil
+}
+
+// ConfigureSecrets will update the Deployment spec to include secrets that have been deployed
+// in the kubernetes cluster.  For each requested secret, we inspect the type and add it to the
+// deployment spec as appropriate: secrets with type `SecretTypeDockercfg/SecretTypeDockerjson`
+// are added as ImagePullSecrets all other secrets are mounted as files in the deployments containers.
+func (f *FunctionFactory) ConfigureSecrets(request types.FunctionDeployment, deployment *appsv1.Deployment, existingSecrets map[string]*apiv1.Secret) error {
+	// Add / reference pre-existing secrets within Kubernetes
+	secretVolumeProjections := []apiv1.VolumeProjection{}
+
+	for _, secretName := range request.Secrets {
+		deployedSecret, ok := existingSecrets[secretName]
+		if !ok {
+			return fmt.Errorf("Required secret '%s' was not found in the cluster", secretName)
+		}
+
+		switch deployedSecret.Type {
+
+		case apiv1.SecretTypeDockercfg,
+			apiv1.SecretTypeDockerConfigJson:
+
+			deployment.Spec.Template.Spec.ImagePullSecrets = append(
+				deployment.Spec.Template.Spec.ImagePullSecrets,
+				apiv1.LocalObjectReference{
+					Name: secretName,
+				},
+			)
+		default:
+
+			projectedPaths := []apiv1.KeyToPath{}
+			for secretKey := range deployedSecret.Data {
+				projectedPaths = append(projectedPaths, apiv1.KeyToPath{Key: secretKey, Path: secretKey})
+			}
+
+			projection := &apiv1.SecretProjection{Items: projectedPaths}
+			projection.Name = secretName
+			secretProjection := apiv1.VolumeProjection{
+				Secret: projection,
+			}
+			secretVolumeProjections = append(secretVolumeProjections, secretProjection)
+		}
+	}
+
+	volumeName := fmt.Sprintf("%s-projected-secrets", request.Service)
+	projectedSecrets := apiv1.Volume{
+		Name: volumeName,
+		VolumeSource: apiv1.VolumeSource{
+			Projected: &apiv1.ProjectedVolumeSource{
+				Sources: secretVolumeProjections,
+			},
+		},
+	}
+
+	// remove the existing secrets volume, if we can find it. The update volume will be
+	// added below
+	existingVolumes := removeVolume(volumeName, deployment.Spec.Template.Spec.Volumes)
+	deployment.Spec.Template.Spec.Volumes = existingVolumes
+	if len(secretVolumeProjections) > 0 {
+		deployment.Spec.Template.Spec.Volumes = append(existingVolumes, projectedSecrets)
+	}
+
+	// add mount secret as a file
+	updatedContainers := []apiv1.Container{}
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		mount := apiv1.VolumeMount{
+			Name:      volumeName,
+			ReadOnly:  true,
+			MountPath: secretsMountPath,
+		}
+
+		// remove the existing secrets volume mount, if we can find it. We update it later.
+		container.VolumeMounts = removeVolumeMount(volumeName, container.VolumeMounts)
+		if len(secretVolumeProjections) > 0 {
+			container.VolumeMounts = append(container.VolumeMounts, mount)
+		}
+
+		updatedContainers = append(updatedContainers, container)
+	}
+
+	deployment.Spec.Template.Spec.Containers = updatedContainers
+
+	return nil
+}

--- a/vendor/github.com/openfaas/faas-netes/types/read_config.go
+++ b/vendor/github.com/openfaas/faas-netes/types/read_config.go
@@ -3,91 +3,35 @@
 package types
 
 import (
-	"os"
-	"strconv"
-	"time"
+	ftypes "github.com/openfaas/faas-provider/types"
 )
-
-// OsEnv implements interface to wrap os.Getenv
-type OsEnv struct {
-}
-
-// Getenv wraps os.Getenv
-func (OsEnv) Getenv(key string) string {
-	return os.Getenv(key)
-}
-
-// HasEnv provides interface for os.Getenv
-type HasEnv interface {
-	Getenv(key string) string
-}
 
 // ReadConfig constitutes config from env variables
 type ReadConfig struct {
 }
 
-func parseIntValue(val string, fallback int) int {
-	if len(val) > 0 {
-		parsedVal, parseErr := strconv.Atoi(val)
-		if parseErr == nil && parsedVal >= 0 {
-			return parsedVal
-		}
-	}
-	return fallback
-}
-
-func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
-	if len(val) > 0 {
-		parsedVal, parseErr := strconv.Atoi(val)
-		if parseErr == nil && parsedVal >= 0 {
-			return time.Duration(parsedVal) * time.Second
-		}
-	}
-
-	duration, durationErr := time.ParseDuration(val)
-	if durationErr != nil {
-		return fallback
-	}
-
-	return duration
-}
-
-func parseBoolValue(val string, fallback bool) bool {
-	if len(val) > 0 {
-		return val == "true"
-	}
-	return fallback
-}
-
-func parseString(val string, fallback string) string {
-	if len(val) > 0 {
-		return val
-	}
-	return fallback
-}
-
 // Read fetches config from environmental variables.
-func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
+func (ReadConfig) Read(hasEnv ftypes.HasEnv) (BootstrapConfig, error) {
 	cfg := BootstrapConfig{}
 
-	httpProbe := parseBoolValue(hasEnv.Getenv("http_probe"), false)
-	setNonRootUser := parseBoolValue(hasEnv.Getenv("set_nonroot_user"), false)
+	faasConfig, err := ftypes.ReadConfig{}.Read(hasEnv)
+	if err != nil {
+		return cfg, err
+	}
 
-	readinessProbeInitialDelaySeconds := parseIntValue(hasEnv.Getenv("readiness_probe_initial_delay_seconds"), 3)
-	readinessProbeTimeoutSeconds := parseIntValue(hasEnv.Getenv("readiness_probe_timeout_seconds"), 1)
-	readinessProbePeriodSeconds := parseIntValue(hasEnv.Getenv("readiness_probe_period_seconds"), 10)
+	cfg.FaaSConfig = *faasConfig
 
-	livenessProbeInitialDelaySeconds := parseIntValue(hasEnv.Getenv("liveness_probe_initial_delay_seconds"), 3)
-	livenessProbeTimeoutSeconds := parseIntValue(hasEnv.Getenv("liveness_probe_timeout_seconds"), 1)
-	livenessProbePeriodSeconds := parseIntValue(hasEnv.Getenv("liveness_probe_period_seconds"), 10)
+	httpProbe := ftypes.ParseBoolValue(hasEnv.Getenv("http_probe"), false)
+	setNonRootUser := ftypes.ParseBoolValue(hasEnv.Getenv("set_nonroot_user"), false)
 
-	readTimeout := parseIntOrDurationValue(hasEnv.Getenv("read_timeout"), time.Second*10)
-	writeTimeout := parseIntOrDurationValue(hasEnv.Getenv("write_timeout"), time.Second*10)
+	readinessProbeInitialDelaySeconds := ftypes.ParseIntValue(hasEnv.Getenv("readiness_probe_initial_delay_seconds"), 3)
+	readinessProbeTimeoutSeconds := ftypes.ParseIntValue(hasEnv.Getenv("readiness_probe_timeout_seconds"), 1)
+	readinessProbePeriodSeconds := ftypes.ParseIntValue(hasEnv.Getenv("readiness_probe_period_seconds"), 10)
 
-	imagePullPolicy := parseString(hasEnv.Getenv("image_pull_policy"), "Always")
-
-	cfg.ReadTimeout = readTimeout
-	cfg.WriteTimeout = writeTimeout
+	livenessProbeInitialDelaySeconds := ftypes.ParseIntValue(hasEnv.Getenv("liveness_probe_initial_delay_seconds"), 3)
+	livenessProbeTimeoutSeconds := ftypes.ParseIntValue(hasEnv.Getenv("liveness_probe_timeout_seconds"), 1)
+	livenessProbePeriodSeconds := ftypes.ParseIntValue(hasEnv.Getenv("liveness_probe_period_seconds"), 10)
+	imagePullPolicy := ftypes.ParseString(hasEnv.Getenv("image_pull_policy"), "Always")
 
 	cfg.HTTPProbe = httpProbe
 	cfg.SetNonRootUser = setNonRootUser
@@ -102,10 +46,7 @@ func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
 
 	cfg.ImagePullPolicy = imagePullPolicy
 
-	defaultTCPPort := 8080
-	cfg.Port = parseIntValue(hasEnv.Getenv("port"), defaultTCPPort)
-
-	return cfg
+	return cfg, nil
 }
 
 // BootstrapConfig for the process.
@@ -120,8 +61,6 @@ type BootstrapConfig struct {
 	LivenessProbeInitialDelaySeconds  int
 	LivenessProbeTimeoutSeconds       int
 	LivenessProbePeriodSeconds        int
-	ReadTimeout                       time.Duration
-	WriteTimeout                      time.Duration
 	ImagePullPolicy                   string
-	Port                              int
+	FaaSConfig                        ftypes.FaaSConfig
 }

--- a/vendor/github.com/openfaas/faas-provider/auth/credentials.go
+++ b/vendor/github.com/openfaas/faas-provider/auth/credentials.go
@@ -17,7 +17,7 @@ type BasicAuthCredentials struct {
 }
 
 type ReadBasicAuth interface {
-	Read() (error, *BasicAuthCredentials)
+	Read() (*BasicAuthCredentials, error)
 }
 
 type ReadBasicAuthFromDisk struct {

--- a/vendor/github.com/openfaas/faas-provider/httputil/writers.go
+++ b/vendor/github.com/openfaas/faas-provider/httputil/writers.go
@@ -1,0 +1,12 @@
+package httputil
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Errorf sets the response status code and write formats the provided message as the
+// response body
+func Errorf(w http.ResponseWriter, statusCode int, msg string, args ...interface{}) {
+	http.Error(w, fmt.Sprintf(msg, args...), statusCode)
+}

--- a/vendor/github.com/openfaas/faas-provider/logs/handler.go
+++ b/vendor/github.com/openfaas/faas-provider/logs/handler.go
@@ -1,0 +1,143 @@
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/openfaas/faas-provider/httputil"
+)
+
+// Requester submits queries the logging system.
+// This will be passed to the log handler constructor.
+type Requester interface {
+	// Query submits a log request to the actual logging system.
+	Query(context.Context, Request) (<-chan Message, error)
+}
+
+// NewLogHandlerFunc creates an http HandlerFunc from the supplied log Requestor.
+func NewLogHandlerFunc(requestor Requester, timeout time.Duration) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			defer r.Body.Close()
+		}
+
+		cn, ok := w.(http.CloseNotifier)
+		if !ok {
+			log.Println("LogHandler: response is not a CloseNotifier, required for streaming response")
+			http.NotFound(w, r)
+			return
+		}
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			log.Println("LogHandler: response is not a Flusher, required for streaming response")
+			http.NotFound(w, r)
+			return
+		}
+
+		logRequest, err := parseRequest(r)
+		if err != nil {
+			log.Printf("LogHandler: could not parse request %s", err)
+			httputil.Errorf(w, http.StatusUnprocessableEntity, "could not parse the log request")
+			return
+		}
+
+		ctx, cancelQuery := context.WithTimeout(r.Context(), timeout)
+		defer cancelQuery()
+		messages, err := requestor.Query(ctx, logRequest)
+		if err != nil {
+			// add smarter error handling here
+			httputil.Errorf(w, http.StatusInternalServerError, "function log request failed")
+			return
+		}
+
+		// Send the initial headers saying we're gonna stream the response.
+		w.Header().Set("Connection", "Keep-Alive")
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.Header().Set(http.CanonicalHeaderKey("Content-Type"), "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+
+		// ensure that we always try to send the closing chunk, not the inverted order due to how
+		// the defer stack works. We need two flush statements to ensure that the empty slice is
+		// sent as its own chunk
+		defer flusher.Flush()
+		defer w.Write([]byte{})
+		defer flusher.Flush()
+
+		jsonEncoder := json.NewEncoder(w)
+		for messages != nil {
+			select {
+			case <-cn.CloseNotify():
+				log.Println("LogHandler: client stopped listening")
+				return
+			case msg, ok := <-messages:
+				if !ok {
+					log.Println("LogHandler: end of log stream")
+					messages = nil
+					return
+				}
+
+				// serialize and write the msg to the http ResponseWriter
+				err := jsonEncoder.Encode(msg)
+				if err != nil {
+					// can't actually write the status header here so we should json serialize an error
+					// and return that because we have already sent the content type and status code
+					log.Printf("LogHandler: failed to serialize log message: '%s'\n", msg.String())
+					log.Println(err.Error())
+					// write json error message here ?
+					jsonEncoder.Encode(Message{Text: "failed to serialize log message"})
+					flusher.Flush()
+					return
+				}
+
+				flusher.Flush()
+			}
+		}
+
+		return
+	}
+}
+
+// parseRequest extracts the logRequest from the GET variables or from the POST body
+func parseRequest(r *http.Request) (logRequest Request, err error) {
+	query := r.URL.Query()
+	logRequest.Name = getValue(query, "name")
+	logRequest.Instance = getValue(query, "instance")
+	tailStr := getValue(query, "tail")
+	if tailStr != "" {
+		logRequest.Tail, err = strconv.Atoi(tailStr)
+		if err != nil {
+			return logRequest, err
+		}
+	}
+
+	// ignore error because it will default to false if we can't parse it
+	logRequest.Follow, _ = strconv.ParseBool(getValue(query, "follow"))
+
+	sinceStr := getValue(query, "since")
+	if sinceStr != "" {
+		since, err := time.Parse(time.RFC3339, sinceStr)
+		logRequest.Since = &since
+		if err != nil {
+			return logRequest, err
+		}
+	}
+
+	return logRequest, nil
+}
+
+// getValue returns the value for the given key. If the key has more than one value, it returns the
+// last value. if the value does not exist, it returns the empty string.
+func getValue(queryValues url.Values, name string) string {
+	values := queryValues[name]
+	if len(values) == 0 {
+		return ""
+	}
+
+	return values[len(values)-1]
+}

--- a/vendor/github.com/openfaas/faas-provider/logs/logs.go
+++ b/vendor/github.com/openfaas/faas-provider/logs/logs.go
@@ -1,0 +1,50 @@
+// Package logs provides the standard interface and handler for OpenFaaS providers to expose function logs.
+//
+// The package defines the Requester interface that OpenFaaS providers should implement and then expose using
+// the predefined NewLogHandlerFunc. See the example folder for a minimal log provider implementation.
+//
+// The Requester is where the actual specific logic for connecting to and querying the log system should be implemented.
+//
+package logs
+
+import (
+	"fmt"
+	"time"
+)
+
+// Request is the query to return the function logs.
+type Request struct {
+	// Name is the function name and is required
+	Name string `json:"name"`
+	// Instance is the optional container name, that allows you to request logs from a specific function instance
+	Instance string `json:"instance"`
+	// Since is the optional datetime value to start the logs from
+	Since *time.Time `json:"since"`
+	// Tail sets the maximum number of log messages to return, <=0 means unlimited
+	Tail int `json:"tail"`
+	// Follow is allows the user to request a stream of logs until the timeout
+	Follow bool `json:"follow"`
+}
+
+// String implements that Stringer interface and prints the log Request in a consistent way that
+// allows you to safely compare if two requests have the same value.
+func (r Request) String() string {
+	return fmt.Sprintf("name:%s instance:%s since:%v tail:%d follow:%v", r.Name, r.Instance, r.Since, r.Tail, r.Follow)
+}
+
+// Message is a specific log message from a function container log stream
+type Message struct {
+	// Name is the function name
+	Name string `json:"name"`
+	// instance is the name/id of the specific function instance
+	Instance string `json:"instance"`
+	// Timestamp is the timestamp of when the log message was recorded
+	Timestamp time.Time `json:"timestamp"`
+	// Text is the raw log message content
+	Text string `json:"text"`
+}
+
+// String implements the Stringer interface and allows for nice and simple string formatting of a log Message.
+func (m Message) String() string {
+	return fmt.Sprintf("%s %s (%s) %s", m.Timestamp.String(), m.Name, m.Instance, m.Text)
+}

--- a/vendor/github.com/openfaas/faas-provider/serve.go
+++ b/vendor/github.com/openfaas/faas-provider/serve.go
@@ -72,7 +72,7 @@ func Serve(handlers *types.FaaSHandlers, config *types.FaaSConfig) {
 	r.HandleFunc("/function/{name:["+NameExpression+"]+}/", handlers.FunctionProxy)
 	r.HandleFunc("/function/{name:["+NameExpression+"]+}/{params:.*}", handlers.FunctionProxy)
 
-	if config.EnableHealth {
+	if handlers.HealthHandler != nil {
 		r.HandleFunc("/healthz", handlers.HealthHandler).Methods("GET")
 	}
 

--- a/vendor/github.com/openfaas/faas-provider/types/config.go
+++ b/vendor/github.com/openfaas/faas-provider/types/config.go
@@ -5,6 +5,11 @@ import (
 	"time"
 )
 
+const (
+	defaultReadTimeout  = 10 * time.Second
+	defaultMaxIdleConns = 1024
+)
+
 // FaaSHandlers provide handlers for OpenFaaS
 type FaaSHandlers struct {
 	// FunctionProxy provides the function invocation proxy logic.  Use proxy.NewHandlerFunc to
@@ -22,7 +27,9 @@ type FaaSHandlers struct {
 	LogHandler http.HandlerFunc
 
 	// UpdateHandler an existing function/service
-	UpdateHandler        http.HandlerFunc
+	UpdateHandler http.HandlerFunc
+	// HealthHandler defines the default health endpoint bound to "/healthz
+	// If the handler is not set, then the "/healthz" path will not be configured
 	HealthHandler        http.HandlerFunc
 	InfoHandler          http.HandlerFunc
 	ListNamespaceHandler http.HandlerFunc
@@ -30,10 +37,51 @@ type FaaSHandlers struct {
 
 // FaaSConfig set config for HTTP handlers
 type FaaSConfig struct {
-	TCPPort         *int
-	ReadTimeout     time.Duration
-	WriteTimeout    time.Duration
-	EnableHealth    bool
+	// TCPPort is the public port for the API.
+	TCPPort *int
+	// HTTP timeout for reading a request from clients.
+	ReadTimeout time.Duration
+	// HTTP timeout for writing a response from functions.
+	WriteTimeout time.Duration
+	// EnableHealth enables/disables the default health endpoint bound to "/healthz".
+	//
+	// Deprecated: basic auth is enabled automatcally by setting the HealthHandler in the FaaSHandlers
+	// struct.  This value is not longer read or used.
+	EnableHealth bool
+	// EnableBasicAuth enforces basic auth on the API. If set, reads secrets from file-system
+	// location specificed in `SecretMountPath`.
 	EnableBasicAuth bool
+	// SecretMountPath specifies where to read secrets from for embedded basic auth.
 	SecretMountPath string
+	// MaxIdleConns with a default value of 1024, can be used for tuning HTTP proxy performance.
+	MaxIdleConns int
+	// MaxIdleConnsPerHost with a default value of 1024, can be used for tuning HTTP proxy performance.
+	MaxIdleConnsPerHost int
+}
+
+// GetReadTimeout is a helper to safely return the configured ReadTimeout or the default value of 10s
+func (c *FaaSConfig) GetReadTimeout() time.Duration {
+	if c.ReadTimeout <= 0*time.Second {
+		return defaultReadTimeout
+	}
+	return c.ReadTimeout
+}
+
+// GetMaxIdleConns is a helper to safely return the configured MaxIdleConns or the default value of 1024
+func (c *FaaSConfig) GetMaxIdleConns() int {
+	if c.MaxIdleConns < 1 {
+		return defaultMaxIdleConns
+	}
+
+	return c.MaxIdleConns
+}
+
+// GetMaxIdleConns is a helper to safely return the configured MaxIdleConns or the default value which
+// should then match the MaxIdleConns
+func (c *FaaSConfig) GetMaxIdleConnsPerHost() int {
+	if c.MaxIdleConnsPerHost < 1 {
+		return c.GetMaxIdleConns()
+	}
+
+	return c.MaxIdleConnsPerHost
 }

--- a/vendor/github.com/openfaas/faas-provider/types/model.go
+++ b/vendor/github.com/openfaas/faas-provider/types/model.go
@@ -93,6 +93,7 @@ type FunctionStatus struct {
 
 // Secret for underlying orchestrator
 type Secret struct {
-	Name  string `json:"name"`
-	Value string `json:"value,omitempty"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+	Value     string `json:"value,omitempty"`
 }

--- a/vendor/github.com/openfaas/faas-provider/types/read_config.go
+++ b/vendor/github.com/openfaas/faas-provider/types/read_config.go
@@ -1,0 +1,112 @@
+package types
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// OsEnv implements interface to wrap os.Getenv
+type OsEnv struct {
+}
+
+// Getenv wraps os.Getenv
+func (OsEnv) Getenv(key string) string {
+	return os.Getenv(key)
+}
+
+// HasEnv provides interface for os.Getenv
+type HasEnv interface {
+	Getenv(key string) string
+}
+
+// ReadConfig constitutes config from env variables
+type ReadConfig struct {
+}
+
+// ParseIntValue parses the the int in val or, if there is an error, returns the
+// specified default value
+func ParseIntValue(val string, fallback int) int {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return parsedVal
+		}
+	}
+	return fallback
+}
+
+// ParseIntOrDurationValue parses the the duration in val or, if there is an error, returns the
+// specified default value
+func ParseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return time.Duration(parsedVal) * time.Second
+		}
+	}
+
+	duration, durationErr := time.ParseDuration(val)
+	if durationErr != nil {
+		return fallback
+	}
+
+	return duration
+}
+
+// ParseBoolValue parses the the boolean in val or, if there is an error, returns the
+// specified default value
+func ParseBoolValue(val string, fallback bool) bool {
+	if len(val) > 0 {
+		return val == "true"
+	}
+	return fallback
+}
+
+// ParseString verifies the string in val is not empty. When empty, it returns the
+// specified default value
+func ParseString(val string, fallback string) string {
+	if len(val) > 0 {
+		return val
+	}
+	return fallback
+}
+
+// Read fetches config from environmental variables.
+func (ReadConfig) Read(hasEnv HasEnv) (*FaaSConfig, error) {
+	cfg := &FaaSConfig{
+		ReadTimeout:     ParseIntOrDurationValue(hasEnv.Getenv("read_timeout"), time.Second*10),
+		WriteTimeout:    ParseIntOrDurationValue(hasEnv.Getenv("write_timeout"), time.Second*10),
+		EnableBasicAuth: ParseBoolValue(hasEnv.Getenv("basic_auth"), false),
+		// default value from Gateway
+		SecretMountPath: ParseString(hasEnv.Getenv("secret_mount_path"), "/run/secrets/"),
+	}
+
+	port := ParseIntValue(hasEnv.Getenv("port"), 8080)
+	cfg.TCPPort = &port
+
+	cfg.MaxIdleConns = 1024
+	maxIdleConns := hasEnv.Getenv("max_idle_conns")
+	if len(maxIdleConns) > 0 {
+		val, err := strconv.Atoi(maxIdleConns)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for max_idle_conns: %s", maxIdleConns)
+		}
+		cfg.MaxIdleConns = val
+
+	}
+
+	cfg.MaxIdleConnsPerHost = 1024
+	maxIdleConnsPerHost := hasEnv.Getenv("max_idle_conns_per_host")
+	if len(maxIdleConnsPerHost) > 0 {
+		val, err := strconv.Atoi(maxIdleConnsPerHost)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for max_idle_conns_per_host: %s", maxIdleConnsPerHost)
+		}
+		cfg.MaxIdleConnsPerHost = val
+
+	}
+
+	return cfg, nil
+}

--- a/vendor/github.com/openfaas/faas/gateway/requests/requests.go
+++ b/vendor/github.com/openfaas/faas/gateway/requests/requests.go
@@ -16,9 +16,3 @@ type AsyncReport struct {
 type DeleteFunctionRequest struct {
 	FunctionName string `json:"functionName"`
 }
-
-// Secret for underlying orchestrator
-type Secret struct {
-	Name  string `json:"name"`
-	Value string `json:"value,omitempty"`
-}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description
<!--- Describe your changes in detail -->

Add logs feature and namespace dummy endpoint

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Adds logs feature from faas-netes so that users can stream logs
from containers. Closes: #99

Partial fix for: #92 which adds a dummy /system/namespaces
endpoint which returns the namespace set at configuration time.
Further work will be required to support CRD reconcilation into
multiple namespaces.

## How Has This Been Tested?

Tested with Kubernetes v1.14.1 on a single-node cluster using
image: openfaas/openfaas-operator:0.9.10-rc1

The RBAC roles also had to be updated in the helm chart in
faas-netes to allow for the logs to be viewed and for pods to be
listed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Impact to existing users
<!-- What must existing users do to adopt this change? -->

Apply the latest helm chart which adds new RBAC permissions to view logs.
