### PR TITLE
Remove sync constraints

### DIFF
--- a/pkg/server/apply.go
+++ b/pkg/server/apply.go
@@ -51,12 +51,6 @@ func makeApplyHandler(namespace string, client clientset.Interface) http.Handler
 				ReadOnlyRootFilesystem: req.ReadOnlyRootFilesystem,
 			},
 		}
-
-		opts := metav1.GetOptions{}
-		oldFunc, _ := client.OpenfaasV1alpha2().Functions(namespace).Get(req.Service, opts)
-		if oldFunc != nil {
-			newFunc.ResourceVersion = oldFunc.ResourceVersion
-		}
 		_, err = client.OpenfaasV1alpha2().Functions(namespace).Update(newFunc)
 		if err != nil {
 			errMsg := err.Error()


### PR DESCRIPTION
## Description

Remove comparison between the `.spec` fields so that resources can be re-synced. The diff constraint is no longer needed since we use an annotation to prevent the mounts from being overwritten.

Do not re-apply `resourceVersion` on function update to allow resources to be re-synced.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fix: #95
Fix: #89

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] I have run the [certifier](https://github.com/openfaas/certifier)

Tested on EKS 1.14 by applying the nodeinfo function with and without changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Impact to existing users
<!-- What must existing users do to adopt this change? -->

No impact to current users.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
